### PR TITLE
[WIP] Support SavedStateHandle.getLiveData / getStateFlow using keys

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
@@ -4,15 +4,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
-interface AsyncKey<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> {
+interface AsyncKey<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> {
   val name: String
   suspend fun get(getter: GETTER): T
   suspend fun set(setter: SETTER, value: T)
 }
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, GETTER, SETTER>.asAsync(
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.asAsync(
   context: CoroutineContext = Dispatchers.Default
-): AsyncKey<T, GETTER, SETTER> = object : AsyncKey<T, GETTER, SETTER> {
+): AsyncKey<T, GETTER, SETTER, BACKED_BY> = object : AsyncKey<T, GETTER, SETTER, BACKED_BY> {
   override val name: String = this@asAsync.name
   override suspend fun get(getter: GETTER): T = withContext(context) { this@asAsync.get(getter) }
   override suspend fun set(setter: SETTER, value: T) = withContext(context) { this@asAsync.set(setter, value) }

--- a/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
@@ -8,9 +8,9 @@ data class AsyncKey<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, 
   val name: String,
   val backingDefault: DefaultProvider<BACKED_BY>,
   val default: DefaultProvider<T>? = null,
-  val getBackingData: (GETTER) -> BACKED_BY,
+  val getBackingData: suspend (GETTER) -> BACKED_BY,
   val mapGet: suspend (BACKED_BY) -> T,
-  val setBackingData: (SETTER, BACKED_BY) -> Unit,
+  val setBackingData: suspend (SETTER, BACKED_BY) -> Unit,
   val mapSet: suspend (T) -> BACKED_BY,
 )
 
@@ -20,8 +20,8 @@ fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any
   name = name,
   backingDefault = backingDefault,
   default = default,
-  getBackingData = getBackingData,
-  setBackingData = setBackingData,
+  getBackingData = { withContext(context) { getBackingData(it) } },
+  setBackingData = { setter, backedBy -> withContext(context) { setBackingData(setter, backedBy) } },
   mapGet = { withContext(context) { mapGet(it) } },
   mapSet = { withContext(context) { mapSet(it) } },
 )

--- a/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
@@ -4,16 +4,36 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
-interface AsyncKey<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> {
+interface AsyncKey<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> {
   val name: String
-  suspend fun get(getter: GETTER): T
-  suspend fun set(setter: SETTER, value: T)
+  val backingDefault: DefaultProvider<BACKED_BY>
+  val default: DefaultProvider<T>? get() = null
+  fun getBackingData(getter: GETTER): BACKED_BY
+  suspend fun mapGet(backedBy: BACKED_BY): T
+  fun setBackingData(setter: SETTER, value: BACKED_BY)
+  suspend fun mapSet(value: T): BACKED_BY
 }
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.asAsync(
-  context: CoroutineContext = Dispatchers.Default
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.asAsync(
+  context: CoroutineContext = Dispatchers.Default,
 ): AsyncKey<T, GETTER, SETTER, BACKED_BY> = object : AsyncKey<T, GETTER, SETTER, BACKED_BY> {
   override val name: String = this@asAsync.name
-  override suspend fun get(getter: GETTER): T = withContext(context) { this@asAsync.get(getter) }
-  override suspend fun set(setter: SETTER, value: T) = withContext(context) { this@asAsync.set(setter, value) }
+  override val backingDefault: DefaultProvider<BACKED_BY> = this@asAsync.backingDefault
+  override val default: DefaultProvider<T>? = this@asAsync.default
+  override fun getBackingData(getter: GETTER): BACKED_BY = this@asAsync.getBackingData(getter)
+  override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@asAsync.setBackingData(setter, value)
+  override suspend fun mapGet(backedBy: BACKED_BY): T = withContext(context) { this@asAsync.mapGet(backedBy) }
+  override suspend fun mapSet(value: T): BACKED_BY = withContext(context) { this@asAsync.mapSet(value) }
 }
+
+suspend fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> AsyncKey<T, GETTER, SETTER, BACKED_BY>.get(
+  getter: GETTER,
+): T {
+  val default = default
+  return if (default != null && !getter.contains(name)) default() else mapGet(getBackingData(getter))
+}
+
+suspend fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> AsyncKey<T, GETTER, SETTER, BACKED_BY>.set(
+  setter: SETTER,
+  value: T,
+) = setBackingData(setter, mapSet(value))

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -16,8 +16,6 @@ interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED
   fun mapGet(backedBy: BACKED_BY): T
   fun setBackingData(setter: SETTER, value: BACKED_BY)
   fun mapSet(value: T): BACKED_BY
-//  fun get(getter: GETTER): T = mapGet(getBackingData(getter))
-//  fun set(setter: SETTER, value: T) = setBackingData(setter, mapSet(value))
 }
 
 fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.get(getter: GETTER): T  {

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -6,7 +6,7 @@ interface KeyValueGetter {
 
 interface KeyValueSetter
 
-interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> {
+interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> {
   val name: String
   fun getBackingData(getter: GETTER): BACKED_BY
   fun mapGet(backedBy: BACKED_BY): T
@@ -20,19 +20,19 @@ interface KeyBuilder {
   val name: String
 }
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.withDefault(
+fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T?, GETTER, SETTER, BACKED_BY>.withDefault(
   default: () -> T,
 ): Key<T, GETTER, SETTER, BACKED_BY> = object : Key<T, GETTER, SETTER, BACKED_BY> {
   override val name: String get() = this@withDefault.name
   override fun getBackingData(getter: GETTER): BACKED_BY = this@withDefault.getBackingData(getter)
   override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@withDefault.setBackingData(setter, value)
   override fun mapSet(value: T): BACKED_BY = this@withDefault.mapSet(value)
-  override fun mapGet(backedBy: BACKED_BY): T = this@withDefault.mapGet(backedBy)
+  override fun mapGet(backedBy: BACKED_BY): T = this@withDefault.mapGet(backedBy) ?: default()
 
-  override fun get(getter: GETTER): T = if (getter.contains(name)) this@withDefault.get(getter) else default()
+  override fun get(getter: GETTER): T = if (getter.contains(name)) mapGet(getBackingData(getter)) else default()
 }
 
-fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
+fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
   mapGet: (T) -> R,
   mapSet: (R) -> T,
 ): Key<R, GETTER, SETTER, BACKED_BY> = object : Key<R, GETTER, SETTER, BACKED_BY> {
@@ -44,6 +44,14 @@ fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKE
   override fun mapSet(value: R): BACKED_BY = this@mapType.mapSet(mapSet.invoke(value))
 }
 
-fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T?, GETTER, SETTER, BACKED_BY>.asNonNull(
-  default: () -> T,
-): Key<T, GETTER, SETTER, BACKED_BY> = mapType(mapGet = { it ?: default() }, mapSet = { it }).withDefault(default)
+internal fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBuilder.nativeKey(
+  get: GETTER.() -> T,
+  set: SETTER.(T) -> Unit,
+): Key<T, GETTER, SETTER, T> =
+  object : Key<T, GETTER, SETTER, T> {
+    override val name: String = this@nativeKey.name
+    override fun mapGet(backedBy: T): T = backedBy
+    override fun mapSet(value: T): T = value
+    override fun getBackingData(getter: GETTER): T = get.invoke(getter)
+    override fun setBackingData(setter: SETTER, value: T) = set.invoke(setter, value)
+  }

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -6,24 +6,29 @@ interface KeyValueGetter {
 
 interface KeyValueSetter
 
-typealias DefaultProvider<T> = ()->T
+typealias DefaultProvider<T> = () -> T
 
-interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> {
-  val name: String
-  val backingDefault: DefaultProvider<BACKED_BY>
-  val default: DefaultProvider<T>? get() = null
-  fun getBackingData(getter: GETTER): BACKED_BY
-  fun mapGet(backedBy: BACKED_BY): T
-  fun setBackingData(setter: SETTER, value: BACKED_BY)
-  fun mapSet(value: T): BACKED_BY
-}
+data class Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?>(
+  val name: String,
+  val backingDefault: DefaultProvider<BACKED_BY>,
+  val default: DefaultProvider<T>? = null,
+  val getBackingData: (GETTER) -> BACKED_BY,
+  val mapGet: (BACKED_BY) -> T,
+  val setBackingData: (SETTER, BACKED_BY) -> Unit,
+  val mapSet: (T) -> BACKED_BY,
+)
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.get(getter: GETTER): T  {
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.get(
+  getter: GETTER,
+): T {
   val default = default
   return if (default != null && !getter.contains(name)) default() else mapGet(getBackingData(getter))
 }
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.set(setter: SETTER, value: T) =
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.set(
+  setter: SETTER,
+  value: T,
+) =
   setBackingData(setter, mapSet(value))
 
 interface KeyBuilder {
@@ -32,40 +37,38 @@ interface KeyBuilder {
 
 fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T?, GETTER, SETTER, BACKED_BY>.withDefault(
   default: () -> T,
-): Key<T, GETTER, SETTER, BACKED_BY> = object : Key<T, GETTER, SETTER, BACKED_BY> {
-  override val name: String get() = this@withDefault.name
-  override val default: DefaultProvider<T>? = default
-  override val backingDefault: DefaultProvider<BACKED_BY> = this@withDefault.backingDefault
-  override fun getBackingData(getter: GETTER): BACKED_BY = this@withDefault.getBackingData(getter)
-  override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@withDefault.setBackingData(setter, value)
-  override fun mapSet(value: T): BACKED_BY = this@withDefault.mapSet(value)
-  override fun mapGet(backedBy: BACKED_BY): T = this@withDefault.mapGet(backedBy) ?: default()
-}
+): Key<T, GETTER, SETTER, BACKED_BY> = Key(
+  name = name,
+  default = default,
+  backingDefault = backingDefault,
+  getBackingData = getBackingData,
+  setBackingData = setBackingData,
+  mapSet = mapSet,
+  mapGet = { mapGet(it) ?: default() }
+)
 
 fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
   mapGet: (T) -> R,
   mapSet: (R) -> T,
-): Key<R, GETTER, SETTER, BACKED_BY> = object : Key<R, GETTER, SETTER, BACKED_BY> {
-  override val name: String get() = this@mapType.name
-  override val backingDefault: DefaultProvider<BACKED_BY> = this@mapType.backingDefault
-  override val default: DefaultProvider<R>? = this@mapType.default?.let { { mapGet(it.invoke()) } }
-  override fun getBackingData(getter: GETTER): BACKED_BY = this@mapType.getBackingData(getter)
-  override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@mapType.setBackingData(setter, value)
-
-  override fun mapGet(backedBy: BACKED_BY): R = mapGet.invoke(this@mapType.mapGet(backedBy))
-  override fun mapSet(value: R): BACKED_BY = this@mapType.mapSet(mapSet.invoke(value))
-}
+): Key<R, GETTER, SETTER, BACKED_BY> = Key(
+  name = name,
+  default = default?.let { { mapGet(it()) } },
+  backingDefault = backingDefault,
+  getBackingData = getBackingData,
+  setBackingData = setBackingData,
+  mapSet = { this@mapType.mapSet(mapSet(it)) },
+  mapGet = { mapGet(this@mapType.mapGet(it)) }
+)
 
 internal fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBuilder.nativeKey(
   get: GETTER.() -> T,
   set: SETTER.(T) -> Unit,
   backingDefault: DefaultProvider<T>,
-): Key<T, GETTER, SETTER, T> =
-  object : Key<T, GETTER, SETTER, T> {
-    override val name: String = this@nativeKey.name
-    override val backingDefault: DefaultProvider<T> = backingDefault
-    override fun mapGet(backedBy: T): T = backedBy
-    override fun mapSet(value: T): T = value
-    override fun getBackingData(getter: GETTER): T = get.invoke(getter)
-    override fun setBackingData(setter: SETTER, value: T) = set.invoke(setter, value)
-  }
+): Key<T, GETTER, SETTER, T> = Key(
+  name = name,
+  backingDefault = backingDefault,
+  mapGet = { it },
+  mapSet = { it },
+  getBackingData = get,
+  setBackingData = set,
+)

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -8,8 +8,12 @@ interface KeyValueSetter
 
 interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> {
   val name: String
-  fun get(getter: GETTER): T
-  fun set(setter: SETTER, value: T)
+  fun getBackingData(getter: GETTER): BACKED_BY
+  fun mapGet(backedBy: BACKED_BY): T
+  fun setBackingData(setter: SETTER, value: BACKED_BY)
+  fun mapSet(value: T): BACKED_BY
+  fun get(getter: GETTER): T = mapGet(getBackingData(getter))
+  fun set(setter: SETTER, value: T) = setBackingData(setter, mapSet(value))
 }
 
 interface KeyBuilder {
@@ -19,23 +23,27 @@ interface KeyBuilder {
 fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.withDefault(
   default: () -> T,
 ): Key<T, GETTER, SETTER, BACKED_BY> = object : Key<T, GETTER, SETTER, BACKED_BY> {
-  override val name: String = this@withDefault.name
+  override val name: String get() = this@withDefault.name
+  override fun getBackingData(getter: GETTER): BACKED_BY = this@withDefault.getBackingData(getter)
+  override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@withDefault.setBackingData(setter, value)
+  override fun mapSet(value: T): BACKED_BY = this@withDefault.mapSet(value)
+  override fun mapGet(backedBy: BACKED_BY): T = this@withDefault.mapGet(backedBy)
+
   override fun get(getter: GETTER): T = if (getter.contains(name)) this@withDefault.get(getter) else default()
-  override fun set(setter: SETTER, value: T) = this@withDefault.set(setter, value)
 }
 
 fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
   mapGet: (T) -> R,
   mapSet: (R) -> T,
 ): Key<R, GETTER, SETTER, BACKED_BY> = object : Key<R, GETTER, SETTER, BACKED_BY> {
-  override val name: String = this@mapType.name
-  override fun get(getter: GETTER): R = mapGet(this@mapType.get(getter))
-  override fun set(setter: SETTER, value: R) = this@mapType.set(setter, mapSet(value))
+  override val name: String get() = this@mapType.name
+  override fun getBackingData(getter: GETTER): BACKED_BY = this@mapType.getBackingData(getter)
+  override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@mapType.setBackingData(setter, value)
+
+  override fun mapGet(backedBy: BACKED_BY): R = mapGet.invoke(this@mapType.mapGet(backedBy))
+  override fun mapSet(value: R): BACKED_BY = this@mapType.mapSet(mapSet.invoke(value))
 }
 
 fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T?, GETTER, SETTER, BACKED_BY>.asNonNull(
   default: () -> T,
-): Key<T, GETTER, SETTER, BACKED_BY> = mapType(
-  mapGet = { it ?: default() },
-  mapSet = { it }
-).withDefault(default)
+): Key<T, GETTER, SETTER, BACKED_BY> = mapType(mapGet = { it ?: default() }, mapSet = { it }).withDefault(default)

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -6,15 +6,27 @@ interface KeyValueGetter {
 
 interface KeyValueSetter
 
+typealias DefaultProvider<T> = ()->T
+
 interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> {
   val name: String
+  val backingDefault: DefaultProvider<BACKED_BY>
+  val default: DefaultProvider<T>? get() = null
   fun getBackingData(getter: GETTER): BACKED_BY
   fun mapGet(backedBy: BACKED_BY): T
   fun setBackingData(setter: SETTER, value: BACKED_BY)
   fun mapSet(value: T): BACKED_BY
-  fun get(getter: GETTER): T = mapGet(getBackingData(getter))
-  fun set(setter: SETTER, value: T) = setBackingData(setter, mapSet(value))
+//  fun get(getter: GETTER): T = mapGet(getBackingData(getter))
+//  fun set(setter: SETTER, value: T) = setBackingData(setter, mapSet(value))
 }
+
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.get(getter: GETTER): T  {
+  val default = default
+  return if (default != null && !getter.contains(name)) default() else mapGet(getBackingData(getter))
+}
+
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.set(setter: SETTER, value: T) =
+  setBackingData(setter, mapSet(value))
 
 interface KeyBuilder {
   val name: String
@@ -24,12 +36,12 @@ fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?
   default: () -> T,
 ): Key<T, GETTER, SETTER, BACKED_BY> = object : Key<T, GETTER, SETTER, BACKED_BY> {
   override val name: String get() = this@withDefault.name
+  override val default: DefaultProvider<T>? = default
+  override val backingDefault: DefaultProvider<BACKED_BY> = this@withDefault.backingDefault
   override fun getBackingData(getter: GETTER): BACKED_BY = this@withDefault.getBackingData(getter)
   override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@withDefault.setBackingData(setter, value)
   override fun mapSet(value: T): BACKED_BY = this@withDefault.mapSet(value)
   override fun mapGet(backedBy: BACKED_BY): T = this@withDefault.mapGet(backedBy) ?: default()
-
-  override fun get(getter: GETTER): T = if (getter.contains(name)) mapGet(getBackingData(getter)) else default()
 }
 
 fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY : Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
@@ -37,6 +49,8 @@ fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKE
   mapSet: (R) -> T,
 ): Key<R, GETTER, SETTER, BACKED_BY> = object : Key<R, GETTER, SETTER, BACKED_BY> {
   override val name: String get() = this@mapType.name
+  override val backingDefault: DefaultProvider<BACKED_BY> = this@mapType.backingDefault
+  override val default: DefaultProvider<R>? = this@mapType.default?.let { { mapGet(it.invoke()) } }
   override fun getBackingData(getter: GETTER): BACKED_BY = this@mapType.getBackingData(getter)
   override fun setBackingData(setter: SETTER, value: BACKED_BY) = this@mapType.setBackingData(setter, value)
 
@@ -47,9 +61,11 @@ fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKE
 internal fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBuilder.nativeKey(
   get: GETTER.() -> T,
   set: SETTER.(T) -> Unit,
+  backingDefault: DefaultProvider<T>,
 ): Key<T, GETTER, SETTER, T> =
   object : Key<T, GETTER, SETTER, T> {
     override val name: String = this@nativeKey.name
+    override val backingDefault: DefaultProvider<T> = backingDefault
     override fun mapGet(backedBy: T): T = backedBy
     override fun mapSet(value: T): T = value
     override fun getBackingData(getter: GETTER): T = get.invoke(getter)

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -6,7 +6,7 @@ interface KeyValueGetter {
 
 interface KeyValueSetter
 
-interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> {
+interface Key<T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> {
   val name: String
   fun get(getter: GETTER): T
   fun set(setter: SETTER, value: T)
@@ -16,26 +16,26 @@ interface KeyBuilder {
   val name: String
 }
 
-fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, GETTER, SETTER>.withDefault(
+fun <T : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.withDefault(
   default: () -> T,
-): Key<T, GETTER, SETTER> = object : Key<T, GETTER, SETTER> {
+): Key<T, GETTER, SETTER, BACKED_BY> = object : Key<T, GETTER, SETTER, BACKED_BY> {
   override val name: String = this@withDefault.name
   override fun get(getter: GETTER): T = if (getter.contains(name)) this@withDefault.get(getter) else default()
   override fun set(setter: SETTER, value: T) = this@withDefault.set(setter, value)
 }
 
-fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, GETTER, SETTER>.mapType(
+fun <T : Any?, R : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T, GETTER, SETTER, BACKED_BY>.mapType(
   mapGet: (T) -> R,
   mapSet: (R) -> T,
-): Key<R, GETTER, SETTER> = object : Key<R, GETTER, SETTER> {
+): Key<R, GETTER, SETTER, BACKED_BY> = object : Key<R, GETTER, SETTER, BACKED_BY> {
   override val name: String = this@mapType.name
   override fun get(getter: GETTER): R = mapGet(this@mapType.get(getter))
   override fun set(setter: SETTER, value: R) = this@mapType.set(setter, mapSet(value))
 }
 
-fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, GETTER, SETTER>.asNonNull(
+fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter, BACKED_BY: Any?> Key<T?, GETTER, SETTER, BACKED_BY>.asNonNull(
   default: () -> T,
-): Key<T, GETTER, SETTER> = mapType(
+): Key<T, GETTER, SETTER, BACKED_BY> = mapType(
   mapGet = { it ?: default() },
   mapSet = { it }
 ).withDefault(default)

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeyValueStore.kt
@@ -11,7 +11,7 @@ interface PrimitiveKeyValueSetter : KeyValueSetter {
   fun setString(name: String, value: String?)
 }
 
-fun <T> PrimitiveKeyValueGetter.get(key: PrimitiveKey<T>): T = key.get(this)
-fun <T> PrimitiveKeyValueSetter.set(key: PrimitiveKey<T>, value: T) = key.set(this, value)
-suspend fun <T> PrimitiveKeyValueGetter.get(key: AsyncPrimitiveKey<T>): T = key.get(this)
-suspend fun <T> PrimitiveKeyValueSetter.set(key: AsyncPrimitiveKey<T>, value: T) = key.set(this, value)
+fun <T, BACKED_BY> PrimitiveKeyValueGetter.get(key: PrimitiveKey<T, BACKED_BY>): T = key.get(this)
+fun <T, BACKED_BY> PrimitiveKeyValueSetter.set(key: PrimitiveKey<T, BACKED_BY>, value: T) = key.set(this, value)
+suspend fun <T, BACKED_BY> PrimitiveKeyValueGetter.get(key: AsyncPrimitiveKey<T, BACKED_BY>): T = key.get(this)
+suspend fun <T, BACKED_BY> PrimitiveKeyValueSetter.set(key: AsyncPrimitiveKey<T, BACKED_BY>, value: T) = key.set(this, value)

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -1,31 +1,31 @@
 package com.episode6.typed2
 
-typealias PrimitiveKey<T> = Key<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
-typealias AsyncPrimitiveKey<T> = AsyncKey<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
+typealias PrimitiveKey<T, BACKED_BY> = Key<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter, BACKED_BY>
+typealias AsyncPrimitiveKey<T, BACKED_BY> = AsyncKey<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter, BACKED_BY>
 
 interface PrimitiveKeyBuilder : KeyBuilder
 
-fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String> = string { default }
-fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String> = string().asNonNull(default)
-fun PrimitiveKeyBuilder.string(): PrimitiveKey<String?> = key(
+fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String?> = string { default }
+fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().asNonNull(default)
+fun PrimitiveKeyBuilder.string(): PrimitiveKey<String?, String?> = key(
   get = { getString(name, null) },
   set = { setString(name, it) }
 )
 
-fun PrimitiveKeyBuilder.int(default: Int): PrimitiveKey<Int> = int { default }
-fun PrimitiveKeyBuilder.int(default: () -> Int): PrimitiveKey<Int> = key(
+fun PrimitiveKeyBuilder.int(default: Int): PrimitiveKey<Int, Int> = int { default }
+fun PrimitiveKeyBuilder.int(default: () -> Int): PrimitiveKey<Int, Int> = key(
   get = { getInt(name, default()) },
   set = { setInt(name, it) }
 )
-fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?> = string().mapType(
+fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?, String?> = string().mapType(
   mapGet = { it?.toInt() },
   mapSet = { it?.toString() }
 )
 
-private fun <T : Any?> PrimitiveKeyBuilder.key(
+private fun <T : Any?, BACKED_BY: Any?> PrimitiveKeyBuilder.key(
   get: PrimitiveKeyValueGetter.() -> T,
   set: PrimitiveKeyValueSetter.(T) -> Unit,
-) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter> {
+) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter, BACKED_BY> {
   override val name: String = this@key.name
   override fun get(getter: PrimitiveKeyValueGetter): T = getter.get()
   override fun set(setter: PrimitiveKeyValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -28,6 +28,9 @@ private fun <T : Any?> PrimitiveKeyBuilder.key(
   set: PrimitiveKeyValueSetter.(T) -> Unit,
 ) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter, T> {
   override val name: String = this@key.name
-  override fun get(getter: PrimitiveKeyValueGetter): T = getter.get()
-  override fun set(setter: PrimitiveKeyValueSetter, value: T) = setter.set(value)
+  override fun mapGet(backedBy: T): T = backedBy
+  override fun mapSet(value: T): T = value
+
+  override fun getBackingData(getter: PrimitiveKeyValueGetter): T = get.invoke(getter)
+  override fun setBackingData(setter: PrimitiveKeyValueSetter, value: T) = set.invoke(setter, value)
 }

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -10,13 +10,15 @@ fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String?> =
 fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().withDefault(default)
 fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> = nativeKey(
   get = { getString(name, null) },
-  set = { setString(name, it) }
+  set = { setString(name, it) },
+  backingDefault = { null }
 )
 
 fun PrimitiveKeyBuilder.int(default: Int): NativePrimitiveKey<Int> = int { default }
 fun PrimitiveKeyBuilder.int(default: () -> Int): NativePrimitiveKey<Int> = nativeKey(
   get = { getInt(name, default()) },
-  set = { setInt(name, it) }
+  set = { setInt(name, it) },
+  backingDefault = default
 )
 
 fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?, String?> = string().mapType(

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -7,30 +7,19 @@ typealias NativePrimitiveKey<T> = PrimitiveKey<T, T>
 interface PrimitiveKeyBuilder : KeyBuilder
 
 fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String?> = string { default }
-fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().asNonNull(default)
-fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> = key(
+fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().withDefault(default)
+fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> = nativeKey(
   get = { getString(name, null) },
   set = { setString(name, it) }
 )
 
 fun PrimitiveKeyBuilder.int(default: Int): NativePrimitiveKey<Int> = int { default }
-fun PrimitiveKeyBuilder.int(default: () -> Int): NativePrimitiveKey<Int> = key(
+fun PrimitiveKeyBuilder.int(default: () -> Int): NativePrimitiveKey<Int> = nativeKey(
   get = { getInt(name, default()) },
   set = { setInt(name, it) }
 )
+
 fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?, String?> = string().mapType(
   mapGet = { it?.toInt() },
   mapSet = { it?.toString() }
 )
-
-private fun <T : Any?> PrimitiveKeyBuilder.key(
-  get: PrimitiveKeyValueGetter.() -> T,
-  set: PrimitiveKeyValueSetter.(T) -> Unit,
-) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter, T> {
-  override val name: String = this@key.name
-  override fun mapGet(backedBy: T): T = backedBy
-  override fun mapSet(value: T): T = value
-
-  override fun getBackingData(getter: PrimitiveKeyValueGetter): T = get.invoke(getter)
-  override fun setBackingData(setter: PrimitiveKeyValueSetter, value: T) = set.invoke(setter, value)
-}

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -6,8 +6,12 @@ typealias NativePrimitiveKey<T> = PrimitiveKey<T, T>
 
 interface PrimitiveKeyBuilder : KeyBuilder
 
-fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String?> = string { default }
-fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().withDefault(default)
+fun PrimitiveKeyBuilder.string(default: String): NativePrimitiveKey<String> = string { default }
+fun PrimitiveKeyBuilder.string(default: () -> String): NativePrimitiveKey<String> = nativeKey(
+  get = { getString(name, default()) ?: default() },
+  set = { setString(name, it) },
+  backingDefault = default
+)
 fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> = nativeKey(
   get = { getString(name, null) },
   set = { setString(name, it) },

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -2,18 +2,19 @@ package com.episode6.typed2
 
 typealias PrimitiveKey<T, BACKED_BY> = Key<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter, BACKED_BY>
 typealias AsyncPrimitiveKey<T, BACKED_BY> = AsyncKey<T, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter, BACKED_BY>
+typealias NativePrimitiveKey<T> = PrimitiveKey<T, T>
 
 interface PrimitiveKeyBuilder : KeyBuilder
 
 fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String?> = string { default }
 fun PrimitiveKeyBuilder.string(default: () -> String): PrimitiveKey<String, String?> = string().asNonNull(default)
-fun PrimitiveKeyBuilder.string(): PrimitiveKey<String?, String?> = key(
+fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> = key(
   get = { getString(name, null) },
   set = { setString(name, it) }
 )
 
-fun PrimitiveKeyBuilder.int(default: Int): PrimitiveKey<Int, Int> = int { default }
-fun PrimitiveKeyBuilder.int(default: () -> Int): PrimitiveKey<Int, Int> = key(
+fun PrimitiveKeyBuilder.int(default: Int): NativePrimitiveKey<Int> = int { default }
+fun PrimitiveKeyBuilder.int(default: () -> Int): NativePrimitiveKey<Int> = key(
   get = { getInt(name, default()) },
   set = { setInt(name, it) }
 )
@@ -22,10 +23,10 @@ fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?, String?> = string().mapType(
   mapSet = { it?.toString() }
 )
 
-private fun <T : Any?, BACKED_BY: Any?> PrimitiveKeyBuilder.key(
+private fun <T : Any?> PrimitiveKeyBuilder.key(
   get: PrimitiveKeyValueGetter.() -> T,
   set: PrimitiveKeyValueSetter.(T) -> Unit,
-) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter, BACKED_BY> {
+) = object : Key<T, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter, T> {
   override val name: String = this@key.name
   override fun get(getter: PrimitiveKeyValueGetter): T = getter.get()
   override fun set(setter: PrimitiveKeyValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
@@ -16,7 +16,7 @@ class TypedBundle(private val delegate: Bundle) : BundleValueGetter, BundleValue
 
 fun Bundle.typed(): TypedBundle = TypedBundle(this)
 
-fun <T> Bundle.get(key: BundleKey<T>): T = typed().get(key)
-fun <T> Bundle.set(key: BundleKey<T>, value: T) = typed().set(key, value)
-suspend fun <T> Bundle.get(key: AsyncBundleKey<T>): T = typed().get(key)
-suspend fun <T> Bundle.set(key: AsyncBundleKey<T>, value: T) = typed().set(key, value)
+fun <T, BACKED_BY> Bundle.get(key: BundleKey<T, BACKED_BY>): T = typed().get(key)
+fun <T, BACKED_BY> Bundle.set(key: BundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
+suspend fun <T, BACKED_BY> Bundle.get(key: AsyncBundleKey<T, BACKED_BY>): T = typed().get(key)
+suspend fun <T, BACKED_BY> Bundle.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -5,6 +5,8 @@ import com.episode6.typed2.*
 
 typealias BundleKey<T, BACKED_BY> = Key<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
 typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
+typealias NativeBundleKey<T> = BundleKey<T, T>
+typealias NativeAsyncBundleKey<T> = AsyncBundleKey<T, T>
 
 interface BundleKeyBuilder : PrimitiveKeyBuilder
 open class BundleKeyNamespace(private val prefix: String = "") {
@@ -16,15 +18,15 @@ fun <T : Any, BACKED_BY: Any?> BundleKey<T?, BACKED_BY>.asRequired(): BundleKey<
 
 fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle { default }
 fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle, Bundle?> = bundle().asNonNull(default)
-fun BundleKeyBuilder.bundle(): BundleKey<Bundle?, Bundle?> = key(
+fun BundleKeyBuilder.bundle(): NativeBundleKey<Bundle?> = key(
   get = { getBundle(name) },
   set = { setBundle(name, it) }
 )
 
-private fun <T : Any?, BACKED_BY: Any?> BundleKeyBuilder.key(
+private fun <T : Any?> BundleKeyBuilder.key(
   get: BundleValueGetter.() -> T,
   set: BundleValueSetter.(T) -> Unit,
-) = object : Key<T, BundleValueGetter, BundleValueSetter, BACKED_BY> {
+) = object : Key<T, BundleValueGetter, BundleValueSetter, T> {
   override val name: String = this@key.name
   override fun get(getter: BundleValueGetter): T = getter.get()
   override fun set(setter: BundleValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -23,7 +23,8 @@ fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundl
 fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle, Bundle?> = bundle().withDefault(default)
 fun BundleKeyBuilder.bundle(): NativeBundleKey<Bundle?> = nativeKey(
   get = { getBundle(name) },
-  set = { setBundle(name, it) }
+  set = { setBundle(name, it) },
+  backingDefault = { null }
 )
 
 class RequiredBundleKeyMissing(name: String) : IllegalArgumentException("Required key ($name) missing from bundle")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -1,7 +1,10 @@
 package com.episode6.typed2.bundles
 
 import android.os.Bundle
-import com.episode6.typed2.*
+import com.episode6.typed2.AsyncKey
+import com.episode6.typed2.Key
+import com.episode6.typed2.PrimitiveKeyBuilder
+import com.episode6.typed2.asNonNull
 
 typealias BundleKey<T, BACKED_BY> = Key<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
 typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
@@ -11,10 +14,12 @@ typealias NativeAsyncBundleKey<T> = AsyncBundleKey<T, T>
 interface BundleKeyBuilder : PrimitiveKeyBuilder
 open class BundleKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : BundleKeyBuilder
+
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
 }
 
-fun <T : Any, BACKED_BY: Any?> BundleKey<T?, BACKED_BY>.asRequired(): BundleKey<T, BACKED_BY> = asNonNull { throw RequiredBundleKeyMissing(name) }
+fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.asRequired(): BundleKey<T, BACKED_BY> =
+  asNonNull { throw RequiredBundleKeyMissing(name) }
 
 fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle { default }
 fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle, Bundle?> = bundle().asNonNull(default)
@@ -28,8 +33,11 @@ private fun <T : Any?> BundleKeyBuilder.key(
   set: BundleValueSetter.(T) -> Unit,
 ) = object : Key<T, BundleValueGetter, BundleValueSetter, T> {
   override val name: String = this@key.name
-  override fun get(getter: BundleValueGetter): T = getter.get()
-  override fun set(setter: BundleValueSetter, value: T) = setter.set(value)
+  override fun mapGet(backedBy: T): T = backedBy
+  override fun mapSet(value: T): T = value
+
+  override fun getBackingData(getter: BundleValueGetter): T = get.invoke(getter)
+  override fun setBackingData(setter: BundleValueSetter, value: T) = set.invoke(setter, value)
 }
 
 class RequiredBundleKeyMissing(name: String) : IllegalArgumentException("Required key ($name) missing from bundle")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -3,8 +3,8 @@ package com.episode6.typed2.bundles
 import android.os.Bundle
 import com.episode6.typed2.*
 
-typealias BundleKey<T> = Key<T, in BundleValueGetter, in BundleValueSetter>
-typealias AsyncBundleKey<T> = AsyncKey<T, in BundleValueGetter, in BundleValueSetter>
+typealias BundleKey<T, BACKED_BY> = Key<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
+typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, in BundleValueGetter, in BundleValueSetter, BACKED_BY>
 
 interface BundleKeyBuilder : PrimitiveKeyBuilder
 open class BundleKeyNamespace(private val prefix: String = "") {
@@ -12,19 +12,19 @@ open class BundleKeyNamespace(private val prefix: String = "") {
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
 }
 
-fun <T : Any> BundleKey<T?>.asRequired(): BundleKey<T> = asNonNull { throw RequiredBundleKeyMissing(name) }
+fun <T : Any, BACKED_BY: Any?> BundleKey<T?, BACKED_BY>.asRequired(): BundleKey<T, BACKED_BY> = asNonNull { throw RequiredBundleKeyMissing(name) }
 
-fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle> = bundle { default }
-fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle> = bundle().asNonNull(default)
-fun BundleKeyBuilder.bundle(): BundleKey<Bundle?> = key(
+fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle { default }
+fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle, Bundle?> = bundle().asNonNull(default)
+fun BundleKeyBuilder.bundle(): BundleKey<Bundle?, Bundle?> = key(
   get = { getBundle(name) },
   set = { setBundle(name, it) }
 )
 
-private fun <T : Any?> BundleKeyBuilder.key(
+private fun <T : Any?, BACKED_BY: Any?> BundleKeyBuilder.key(
   get: BundleValueGetter.() -> T,
   set: BundleValueSetter.(T) -> Unit,
-) = object : Key<T, BundleValueGetter, BundleValueSetter> {
+) = object : Key<T, BundleValueGetter, BundleValueSetter, BACKED_BY> {
   override val name: String = this@key.name
   override fun get(getter: BundleValueGetter): T = getter.get()
   override fun set(setter: BundleValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
@@ -11,7 +11,7 @@ interface BundleValueSetter : PrimitiveKeyValueSetter {
   fun setBundle(name: String, value: Bundle?)
 }
 
-fun <T> BundleValueGetter.get(key: BundleKey<T>): T = key.get(this)
-fun <T> BundleValueSetter.set(key: BundleKey<T>, value: T) = key.set(this, value)
-suspend fun <T> BundleValueGetter.get(key: AsyncBundleKey<T>): T = key.get(this)
-suspend fun <T> BundleValueSetter.set(key: AsyncBundleKey<T>, value: T) = key.set(this, value)
+fun <T, BACKED_BY> BundleValueGetter.get(key: BundleKey<T, BACKED_BY>): T = key.get(this)
+fun <T, BACKED_BY> BundleValueSetter.set(key: BundleKey<T, BACKED_BY>, value: T) = key.set(this, value)
+suspend fun <T, BACKED_BY> BundleValueGetter.get(key: AsyncBundleKey<T, BACKED_BY>): T = key.get(this)
+suspend fun <T, BACKED_BY> BundleValueSetter.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = key.set(this, value)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
@@ -1,8 +1,7 @@
 package com.episode6.typed2.bundles
 
 import android.os.Bundle
-import com.episode6.typed2.PrimitiveKeyValueGetter
-import com.episode6.typed2.PrimitiveKeyValueSetter
+import com.episode6.typed2.*
 
 interface BundleValueGetter : PrimitiveKeyValueGetter {
   fun getBundle(name: String): Bundle?

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeyValueStore.kt
@@ -10,9 +10,9 @@ interface PrefValueSetter : PrimitiveKeyValueSetter {
   fun setStringSet(name: String, value: Set<String?>?)
 }
 
-fun <T> PrefValueGetter.get(key: PrefKey<T>): T = key.get(this)
-fun <T> PrefValueSetter.set(key: PrefKey<T>, value: T) = key.set(this, value)
-suspend fun <T> PrefValueGetter.get(key: AsyncPrefKey<T>): T = key.get(this)
-suspend fun <T> PrefValueSetter.set(key: AsyncPrefKey<T>, value: T) = key.set(this, value)
+fun <T, BACKED_BY> PrefValueGetter.get(key: PrefKey<T, BACKED_BY>): T = key.get(this)
+fun <T, BACKED_BY> PrefValueSetter.set(key: PrefKey<T, BACKED_BY>, value: T) = key.set(this, value)
+suspend fun <T, BACKED_BY> PrefValueGetter.get(key: AsyncPrefKey<T, BACKED_BY>): T = key.get(this)
+suspend fun <T, BACKED_BY> PrefValueSetter.set(key: AsyncPrefKey<T, BACKED_BY>, value: T) = key.set(this, value)
 
 

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -4,6 +4,8 @@ import com.episode6.typed2.*
 
 typealias PrefKey<T, BACKED_BY> = Key<T, in PrefValueGetter, in PrefValueSetter, BACKED_BY>
 typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, in PrefValueGetter, in PrefValueSetter, BACKED_BY>
+typealias NativePrefKey<T> = PrefKey<T, T>
+typealias NativeAsyncPrefKey<T> = AsyncPrefKey<T, T>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
 open class PrefNamespace(private val prefix: String = "") {
@@ -18,15 +20,15 @@ fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableS
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }
 )
-fun PrefKeyBuilder.nullableStringSet(): PrefKey<Set<String?>?, Set<String?>?> = key(
+fun PrefKeyBuilder.nullableStringSet(): NativePrefKey<Set<String?>?> = key(
   get = { getStringSet(name, null) },
   set = { setStringSet(name, it) }
 )
 
-private fun <T : Any?, BACKED_BY: Any?> PrefKeyBuilder.key(
+private fun <T : Any?> PrefKeyBuilder.key(
   get: PrefValueGetter.() -> T,
   set: PrefValueSetter.(T) -> Unit,
-) = object : Key<T, PrefValueGetter, PrefValueSetter, BACKED_BY> {
+) = object : Key<T, PrefValueGetter, PrefValueSetter, T> {
   override val name: String = this@key.name
   override fun get(getter: PrefValueGetter): T = getter.get()
   override fun set(setter: PrefValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -22,5 +22,6 @@ fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableS
 )
 fun PrefKeyBuilder.nullableStringSet(): NativePrefKey<Set<String?>?> = nativeKey(
   get = { getStringSet(name, null) },
-  set = { setStringSet(name, it) }
+  set = { setStringSet(name, it) },
+  backingDefault = { null }
 )

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -15,24 +15,12 @@ open class PrefNamespace(private val prefix: String = "") {
 }
 
 fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet { default }
-fun PrefKeyBuilder.stringSet(default: () -> Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().asNonNull(default)
+fun PrefKeyBuilder.stringSet(default: () -> Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().withDefault(default)
 fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }
 )
-fun PrefKeyBuilder.nullableStringSet(): NativePrefKey<Set<String?>?> = key(
+fun PrefKeyBuilder.nullableStringSet(): NativePrefKey<Set<String?>?> = nativeKey(
   get = { getStringSet(name, null) },
   set = { setStringSet(name, it) }
 )
-
-private fun <T : Any?> PrefKeyBuilder.key(
-  get: PrefValueGetter.() -> T,
-  set: PrefValueSetter.(T) -> Unit,
-) = object : Key<T, PrefValueGetter, PrefValueSetter, T> {
-  override val name: String = this@key.name
-  override fun mapGet(backedBy: T): T = backedBy
-  override fun mapSet(value: T): T = value
-
-  override fun getBackingData(getter: PrefValueGetter): T = get.invoke(getter)
-  override fun setBackingData(setter: PrefValueSetter, value: T) = set.invoke(setter, value)
-}

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -2,8 +2,8 @@ package com.episode6.typed2.sharedprefs
 
 import com.episode6.typed2.*
 
-typealias PrefKey<T> = Key<T, in PrefValueGetter, in PrefValueSetter>
-typealias AsyncPrefKey<T> = AsyncKey<T, in PrefValueGetter, in PrefValueSetter>
+typealias PrefKey<T, BACKED_BY> = Key<T, in PrefValueGetter, in PrefValueSetter, BACKED_BY>
+typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, in PrefValueGetter, in PrefValueSetter, BACKED_BY>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
 open class PrefNamespace(private val prefix: String = "") {
@@ -12,21 +12,21 @@ open class PrefNamespace(private val prefix: String = "") {
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)
 }
 
-fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>> = stringSet { default }
-fun PrefKeyBuilder.stringSet(default: () -> Set<String>): PrefKey<Set<String>> = stringSet().asNonNull(default)
-fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?> = nullableStringSet().mapType(
+fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet { default }
+fun PrefKeyBuilder.stringSet(default: () -> Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().asNonNull(default)
+fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }
 )
-fun PrefKeyBuilder.nullableStringSet(): PrefKey<Set<String?>?> = key(
+fun PrefKeyBuilder.nullableStringSet(): PrefKey<Set<String?>?, Set<String?>?> = key(
   get = { getStringSet(name, null) },
   set = { setStringSet(name, it) }
 )
 
-private fun <T : Any?> PrefKeyBuilder.key(
+private fun <T : Any?, BACKED_BY: Any?> PrefKeyBuilder.key(
   get: PrefValueGetter.() -> T,
   set: PrefValueSetter.(T) -> Unit,
-) = object : Key<T, PrefValueGetter, PrefValueSetter> {
+) = object : Key<T, PrefValueGetter, PrefValueSetter, BACKED_BY> {
   override val name: String = this@key.name
   override fun get(getter: PrefValueGetter): T = getter.get()
   override fun set(setter: PrefValueSetter, value: T) = setter.set(value)

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -30,6 +30,9 @@ private fun <T : Any?> PrefKeyBuilder.key(
   set: PrefValueSetter.(T) -> Unit,
 ) = object : Key<T, PrefValueGetter, PrefValueSetter, T> {
   override val name: String = this@key.name
-  override fun get(getter: PrefValueGetter): T = getter.get()
-  override fun set(setter: PrefValueSetter, value: T) = setter.set(value)
+  override fun mapGet(backedBy: T): T = backedBy
+  override fun mapSet(value: T): T = value
+
+  override fun getBackingData(getter: PrefValueGetter): T = get.invoke(getter)
+  override fun setBackingData(setter: PrefValueSetter, value: T) = set.invoke(setter, value)
 }

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
@@ -18,7 +18,7 @@ class TypedSharedPreferences(private val delegate: SharedPreferences) : PrefValu
 fun SharedPreferences.typed(): TypedSharedPreferences = TypedSharedPreferences(this)
 fun SharedPreferences.Editor.typed(): TypedSharedPreferences.Editor = TypedSharedPreferences.Editor(this)
 
-fun <T> SharedPreferences.get(key: PrefKey<T>): T = typed().get(key)
-fun <T> SharedPreferences.Editor.set(key: PrefKey<T>, value: T) = typed().set(key, value)
-suspend fun <T> SharedPreferences.get(key: AsyncPrefKey<T>): T = typed().get(key)
-suspend fun <T> SharedPreferences.Editor.set(key: AsyncPrefKey<T>, value: T) = typed().set(key, value)
+fun <T, BACKED_BY> SharedPreferences.get(key: PrefKey<T, BACKED_BY>): T = typed().get(key)
+fun <T, BACKED_BY> SharedPreferences.Editor.set(key: PrefKey<T, BACKED_BY>, value: T) = typed().set(key, value)
+suspend fun <T, BACKED_BY> SharedPreferences.get(key: AsyncPrefKey<T, BACKED_BY>): T = typed().get(key)
+suspend fun <T, BACKED_BY> SharedPreferences.Editor.set(key: AsyncPrefKey<T, BACKED_BY>, value: T) = typed().set(key, value)

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -21,6 +21,7 @@ mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
 assertk-core = { module = "com.willowtreeapps.assertk:assertk", version = "0.25" }
 turbine-core = { module = "app.cash.turbine:turbine", version = "0.12.0" }
+androidx-testing-arch-core = { module = "androidx.arch.core:core-testing", version = "2.1.0" }
 
 [bundles]
 test-support = [

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -20,6 +20,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-cor
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito-core" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.0.0" }
 assertk-core = { module = "com.willowtreeapps.assertk:assertk", version = "0.25" }
+turbine-core = { module = "app.cash.turbine:turbine", version = "0.12.0" }
 
 [bundles]
 test-support = [

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -11,7 +11,8 @@ mockito-core = "4.8.0"
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
-savedstatehandle = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
+androidx-savedstatehandle = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
+androidx-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidx.lifecycle" }
 
 # test libraries
 junit-core = { module = "junit:junit", version = "4.13.2" }

--- a/saved-state-handle/build.gradle.kts
+++ b/saved-state-handle/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
 
   testImplementation(libs.bundles.test.support)
   testImplementation(libs.turbine.core)
+  testImplementation(libs.androidx.testing.arch.core)
 }

--- a/saved-state-handle/build.gradle.kts
+++ b/saved-state-handle/build.gradle.kts
@@ -11,7 +11,8 @@ android {
 
 dependencies {
   api(project(":core"))
-  implementation(libs.savedstatehandle)
+  implementation(libs.androidx.livedata)
+  implementation(libs.androidx.savedstatehandle)
   implementation(libs.kotlinx.coroutines.core)
   testImplementation(libs.bundles.test.support)
 }

--- a/saved-state-handle/build.gradle.kts
+++ b/saved-state-handle/build.gradle.kts
@@ -14,5 +14,7 @@ dependencies {
   implementation(libs.androidx.livedata)
   implementation(libs.androidx.savedstatehandle)
   implementation(libs.kotlinx.coroutines.core)
+
   testImplementation(libs.bundles.test.support)
+  testImplementation(libs.turbine.core)
 }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, *, *, BACKED_BY>): MutableLiveData<T> {
   val backingLiveData = getLiveData(key.name, key.backingDefault())
   val result = MutableMediatorLiveData<T>(onNewValue = { backingLiveData.value = key.mapSet(it) })
-  backingLiveData.value?.let { result.setValueSkipCallback(key.mapGet(it)) }
+  backingLiveData.value?.let { result.setValueSkipCallback(key.mapGet(it)) } ?: key.default?.invoke()?.let {  result.setValueSkipCallback(it) }
   result.addSource(backingLiveData) { result.setValueSkipCallback(key.mapGet(it)) }
   return result
 }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
@@ -1,0 +1,49 @@
+package com.episode6.typed2.savedstatehandle
+
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asFlow
+import com.episode6.typed2.AsyncKey
+import com.episode6.typed2.Key
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, *, *, BACKED_BY>): MutableLiveData<T> {
+  val backingLiveData = getLiveData(key.name, key.backingDefault())
+  val result = MutableMediatorLiveData<T>(onNewValue = { backingLiveData.value = key.mapSet(it) })
+  backingLiveData.value?.let { result.setValueSkipCallback(key.mapGet(it)) }
+  result.addSource(backingLiveData) { result.setValueSkipCallback(key.mapGet(it)) }
+  return result
+}
+
+fun <T, BACKED_BY> SavedStateHandle.getLiveData(
+  scope: CoroutineScope,
+  key: AsyncKey<T, *, *, BACKED_BY>,
+): MutableLiveData<T> {
+  val newValues = MutableSharedFlow<T>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+  val backingLiveData = getLiveData(key.name, key.backingDefault())
+  val result = MutableMediatorLiveData<T>(onNewValue = { newValues.tryEmit(it) })
+  scope.launch {
+    newValues.map { key.mapSet(it) }.collectLatest { backingLiveData.value = it }
+  }
+  scope.launch {
+    backingLiveData.asFlow().map { key.mapGet(it) }.collectLatest { result.setValueSkipCallback(it) }
+  }
+  return result
+}
+
+private class MutableMediatorLiveData<T>(private val onNewValue: (T) -> Unit) : MediatorLiveData<T>() {
+  override fun setValue(value: T) {
+    super.setValue(value)
+    onNewValue(value)
+  }
+
+  fun setValueSkipCallback(value: T) {
+    super.setValue(value)
+  }
+}

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlow.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlow.kt
@@ -1,0 +1,26 @@
+package com.episode6.typed2.savedstatehandle
+
+import androidx.lifecycle.SavedStateHandle
+import com.episode6.typed2.AsyncKey
+import com.episode6.typed2.Key
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
+  scope: CoroutineScope,
+  key: Key<T, *, *, BACKED_BY>,
+): StateFlow<T> = getStateFlow(key.name, key.backingDefault()).run {
+  map { key.mapGet(it) }.stateIn(scope, SharingStarted.Eagerly, initialValue = key.mapGet(value))
+}
+
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
+  scope: CoroutineScope,
+  key: AsyncKey<T, *, *, BACKED_BY>,
+): StateFlow<T?> = getStateFlow(key.name, key.backingDefault())
+  .map { key.mapGet(it) }
+  .stateIn(scope, SharingStarted.Eagerly, null)
+
+

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -15,7 +15,7 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun contains(name: String): Boolean = delegate.contains(name)
   override fun getBundle(name: String): Bundle? = delegate[name]
   override fun getInt(name: String, default: Int): Int = delegate[name] ?: default
-  override fun getString(name: String, default: String?): String? = delegate[name]
+  override fun getString(name: String, default: String?): String? = delegate[name] ?: default
   override fun setBundle(name: String, value: Bundle?) { delegate[name] = value }
   override fun setInt(name: String, value: Int) { delegate[name] = value }
   override fun setString(name: String, value: String?) { delegate[name] = value }
@@ -31,7 +31,7 @@ suspend fun <T, BACKED_BY> SavedStateHandle.set(key: AsyncBundleKey<T, BACKED_BY
 
 fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: BundleKey<T, BACKED_BY>): MutableLiveData<T> =
   getLiveData<BACKED_BY>(key.name, key.backingDefault())
-    .mapMutable(mapGet = key::mapGet, mapSet = key::mapSet)
+    .mapMutable(mapGet = key.mapGet, mapSet = key.mapSet)
 
 fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: BundleKey<T, BACKED_BY>): StateFlow<T> {
   val stateFlow = getStateFlow<BACKED_BY>(key.name, key.backingDefault())

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -43,14 +43,9 @@ fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: Key
 fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
   scope: CoroutineScope,
   key: AsyncKey<T, *, *, BACKED_BY>,
-): StateFlow<T?> = MutableStateFlow<T?>(null)
-  .also { mutableStateFlow ->
-    scope.launch {
-      getStateFlow(key.name, key.backingDefault())
-        .map { key.mapGet(it) }
-        .collect { mutableStateFlow.value = it }
-    }
-  }.asStateFlow()
+): StateFlow<T?> = getStateFlow(key.name, key.backingDefault())
+    .map { key.mapGet(it) }
+    .stateIn(scope, SharingStarted.Eagerly, null)
 
 private fun <BACKED_BY : Any?, T : Any?> MutableLiveData<BACKED_BY>.mapMutable(
   mapGet: (BACKED_BY) -> T,

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -6,10 +6,8 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.episode6.typed2.bundles.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 
 class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValueGetter, BundleValueSetter {
   override fun contains(name: String): Boolean = delegate.contains(name)
@@ -30,14 +28,25 @@ suspend fun <T, BACKED_BY> SavedStateHandle.get(key: AsyncBundleKey<T, BACKED_BY
 suspend fun <T, BACKED_BY> SavedStateHandle.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
 
 fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: BundleKey<T, BACKED_BY>): MutableLiveData<T> =
-  getLiveData<BACKED_BY>(key.name, key.backingDefault())
+  getLiveData(key.name, key.backingDefault())
     .mapMutable(mapGet = key.mapGet, mapSet = key.mapSet)
 
-fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: BundleKey<T, BACKED_BY>): StateFlow<T> {
-  val stateFlow = getStateFlow<BACKED_BY>(key.name, key.backingDefault())
-  return stateFlow.map { key.mapGet(it) }
-    .stateIn(scope, SharingStarted.Eagerly, initialValue = key.mapGet(stateFlow.value))
-}
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: BundleKey<T, BACKED_BY>): StateFlow<T> =
+  getStateFlow(key.name, key.backingDefault()).run {
+    map { key.mapGet(it) }.stateIn(scope, SharingStarted.Eagerly, initialValue = key.mapGet(value))
+  }
+
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
+  scope: CoroutineScope,
+  key: AsyncBundleKey<T, BACKED_BY>,
+): StateFlow<T?> = MutableStateFlow<T?>(null)
+  .also { mutableStateFlow ->
+    scope.launch {
+      getStateFlow(key.name, key.backingDefault())
+        .map { key.mapGet(it) }
+        .collect { mutableStateFlow.value = it }
+    }
+  }.asStateFlow()
 
 private fun <BACKED_BY : Any?, T : Any?> MutableLiveData<BACKED_BY>.mapMutable(
   mapGet: (BACKED_BY) -> T,

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
+import com.episode6.typed2.AsyncKey
+import com.episode6.typed2.Key
+import com.episode6.typed2.KeyValueGetter
+import com.episode6.typed2.KeyValueSetter
 import com.episode6.typed2.bundles.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
@@ -27,18 +31,18 @@ fun <T, BACKED_BY> SavedStateHandle.set(key: BundleKey<T, BACKED_BY>, value: T) 
 suspend fun <T, BACKED_BY> SavedStateHandle.get(key: AsyncBundleKey<T, BACKED_BY>): T = typed().get(key)
 suspend fun <T, BACKED_BY> SavedStateHandle.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
 
-fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: BundleKey<T, BACKED_BY>): MutableLiveData<T> =
+fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, *, *, BACKED_BY>): MutableLiveData<T> =
   getLiveData(key.name, key.backingDefault())
     .mapMutable(mapGet = key.mapGet, mapSet = key.mapSet)
 
-fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: BundleKey<T, BACKED_BY>): StateFlow<T> =
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: Key<T, *, *, BACKED_BY>): StateFlow<T> =
   getStateFlow(key.name, key.backingDefault()).run {
     map { key.mapGet(it) }.stateIn(scope, SharingStarted.Eagerly, initialValue = key.mapGet(value))
   }
 
 fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
   scope: CoroutineScope,
-  key: AsyncBundleKey<T, BACKED_BY>,
+  key: AsyncKey<T, *, *, BACKED_BY>,
 ): StateFlow<T?> = MutableStateFlow<T?>(null)
   .also { mutableStateFlow ->
     scope.launch {

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -17,7 +17,7 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
 
 fun SavedStateHandle.typed(): TypedSavedStateHandle = TypedSavedStateHandle(this)
 
-fun <T> SavedStateHandle.get(key: BundleKey<T>): T = typed().get(key)
-fun <T> SavedStateHandle.set(key: BundleKey<T>, value: T) = typed().set(key, value)
-suspend fun <T> SavedStateHandle.get(key: AsyncBundleKey<T>): T = typed().get(key)
-suspend fun <T> SavedStateHandle.set(key: AsyncBundleKey<T>, value: T) = typed().set(key, value)
+fun <T, BACKED_BY> SavedStateHandle.get(key: BundleKey<T, BACKED_BY>): T = typed().get(key)
+fun <T, BACKED_BY> SavedStateHandle.set(key: BundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
+suspend fun <T, BACKED_BY> SavedStateHandle.get(key: AsyncBundleKey<T, BACKED_BY>): T = typed().get(key)
+suspend fun <T, BACKED_BY> SavedStateHandle.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -1,17 +1,8 @@
 package com.episode6.typed2.savedstatehandle
 
 import android.os.Bundle
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
-import com.episode6.typed2.AsyncKey
-import com.episode6.typed2.Key
-import com.episode6.typed2.KeyValueGetter
-import com.episode6.typed2.KeyValueSetter
 import com.episode6.typed2.bundles.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
 
 class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValueGetter, BundleValueSetter {
   override fun contains(name: String): Boolean = delegate.contains(name)
@@ -23,45 +14,9 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun setString(name: String, value: String?) { delegate[name] = value }
 }
 
-
 fun SavedStateHandle.typed(): TypedSavedStateHandle = TypedSavedStateHandle(this)
 
 fun <T, BACKED_BY> SavedStateHandle.get(key: BundleKey<T, BACKED_BY>): T = typed().get(key)
 fun <T, BACKED_BY> SavedStateHandle.set(key: BundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
 suspend fun <T, BACKED_BY> SavedStateHandle.get(key: AsyncBundleKey<T, BACKED_BY>): T = typed().get(key)
 suspend fun <T, BACKED_BY> SavedStateHandle.set(key: AsyncBundleKey<T, BACKED_BY>, value: T) = typed().set(key, value)
-
-fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, *, *, BACKED_BY>): MutableLiveData<T> =
-  getLiveData(key.name, key.backingDefault())
-    .mapMutable(mapGet = key.mapGet, mapSet = key.mapSet)
-
-fun <T, BACKED_BY> SavedStateHandle.getStateFlow(scope: CoroutineScope, key: Key<T, *, *, BACKED_BY>): StateFlow<T> =
-  getStateFlow(key.name, key.backingDefault()).run {
-    map { key.mapGet(it) }.stateIn(scope, SharingStarted.Eagerly, initialValue = key.mapGet(value))
-  }
-
-fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
-  scope: CoroutineScope,
-  key: AsyncKey<T, *, *, BACKED_BY>,
-): StateFlow<T?> = getStateFlow(key.name, key.backingDefault())
-    .map { key.mapGet(it) }
-    .stateIn(scope, SharingStarted.Eagerly, null)
-
-private fun <BACKED_BY : Any?, T : Any?> MutableLiveData<BACKED_BY>.mapMutable(
-  mapGet: (BACKED_BY) -> T,
-  mapSet: (T) -> BACKED_BY,
-): MutableLiveData<T> {
-  val result = object : MediatorLiveData<T>() {
-    fun setValueInternal(value: T) {
-      super.setValue(value)
-    }
-
-    override fun setValue(value: T) {
-      super.setValue(value)
-      this@mapMutable.value = mapSet(value)
-    }
-  }
-  value?.let { result.setValueInternal(mapGet(it)) }
-  result.addSource(this) { result.setValueInternal(mapGet(it)) }
-  return result
-}

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -1,0 +1,168 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.typed2.savedstatehandle
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asFlow
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isNull
+import com.episode6.typed2.asAsync
+import com.episode6.typed2.bundles.BundleKeyNamespace
+import com.episode6.typed2.bundles.RequiredBundleKeyMissing
+import com.episode6.typed2.bundles.asRequired
+import com.episode6.typed2.int
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class GetLiveDataTest {
+
+  object Keys : BundleKeyNamespace() {
+    val intKey = key("intKey").int(default = 2)
+    val nullableIntKey = key("nullableInt").int()
+    val requiredInt = key("requiredInt").int().asRequired()
+    val asyncRequiredInt = key("asyncRequiredInt").int().asRequired().asAsync()
+  }
+
+  @get:Rule val instantExecutor = InstantTaskExecutorRule()
+
+  val dispatcher = StandardTestDispatcher()
+
+  @Before
+  fun setup() {
+    Dispatchers.setMain(dispatcher)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  private val savedStateHandle: SavedStateHandle = mock()
+
+  @Test fun testIntStateFlow() = runTest {
+    val backingLiveData: MutableLiveData<Int> = MutableLiveData(Keys.intKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getLiveData<Int>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    launch {
+      val result: MutableLiveData<Int> = savedStateHandle.getLiveData(Keys.intKey)
+
+      assertThat(result.value).isEqualTo(2)
+
+      result.asFlow().test {
+        assertThat(awaitItem()).isEqualTo(2)
+
+        backingLiveData.value = 10
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test fun testNullableIntStateFlow() = runTest {
+    val backingLiveData: MutableLiveData<String?> = MutableLiveData(Keys.nullableIntKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    launch {
+      val result: MutableLiveData<Int?> = savedStateHandle.getLiveData(Keys.nullableIntKey)
+
+      assertThat(result.value).isNull()
+
+      result.asFlow().test {
+        assertThat(awaitItem()).isNull()
+
+        backingLiveData.value = "10"
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test fun testRequiredIntStateFlow_noValue() = runTest {
+    val backingLiveData: MutableLiveData<String?> = MutableLiveData(Keys.requiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    assertThat { savedStateHandle.getLiveData(Keys.requiredInt) }
+      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+  }
+
+  @Test fun testRequiredIntStateFlow_hasValue() = runTest {
+    val backingLiveData: MutableLiveData<String?> = MutableLiveData("5")
+    savedStateHandle.stub {
+      onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    launch {
+      val result: MutableLiveData<Int> = savedStateHandle.getLiveData(key = Keys.requiredInt)
+
+      assertThat(result.value).isEqualTo(5)
+
+      result.asFlow().test {
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingLiveData.value = "10"
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in othe coroutine
+  fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
+    val backingLiveData: MutableLiveData<String?> = MutableLiveData(Keys.asyncRequiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    val result = savedStateHandle.getLiveData(this, Keys.asyncRequiredInt)
+    assertThat(result.value).isNull()
+    result.asFlow().testIn(this)
+  }
+
+  @Test fun testRequiredAsyncIntStateFlow_hasValue() = runTest {
+    val backingLiveData: MutableLiveData<String?> = MutableLiveData("5")
+    savedStateHandle.stub {
+      onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
+    }
+
+    launch {
+      val result: MutableLiveData<Int> = savedStateHandle.getLiveData(this, Keys.asyncRequiredInt)
+
+      result.asFlow().test {
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingLiveData.value = "10"
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+}

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -73,6 +73,14 @@ class GetLiveDataTest {
         assertThat(awaitItem()).isEqualTo(10)
       }
 
+      backingLiveData.asFlow().test {
+        assertThat(awaitItem()).isEqualTo(10)
+
+        result.value = 11
+
+        assertThat(awaitItem()).isEqualTo(11)
+      }
+
       cancel()
     }
   }
@@ -94,6 +102,14 @@ class GetLiveDataTest {
         backingLiveData.value = "10"
 
         assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      backingLiveData.asFlow().test {
+        assertThat(awaitItem()).isEqualTo("10")
+
+        result.value = 11
+
+        assertThat(awaitItem()).isEqualTo("11")
       }
 
       cancel()
@@ -129,6 +145,15 @@ class GetLiveDataTest {
         assertThat(awaitItem()).isEqualTo(10)
       }
 
+      backingLiveData.asFlow().test {
+        assertThat(awaitItem()).isEqualTo("10")
+
+        result.value = 11
+
+        assertThat(awaitItem()).isEqualTo("11")
+      }
+
+
       cancel()
     }
   }
@@ -160,6 +185,14 @@ class GetLiveDataTest {
         backingLiveData.value = "10"
 
         assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      backingLiveData.asFlow().test {
+        assertThat(awaitItem()).isEqualTo("10")
+
+        result.value = 11
+
+        assertThat(awaitItem()).isEqualTo("11")
       }
 
       cancel()

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
@@ -1,0 +1,151 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.typed2.savedstatehandle
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isNull
+import com.episode6.typed2.asAsync
+import com.episode6.typed2.bundles.BundleKeyNamespace
+import com.episode6.typed2.bundles.RequiredBundleKeyMissing
+import com.episode6.typed2.bundles.asRequired
+import com.episode6.typed2.int
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class GetStateFlowTest {
+
+  object Keys : BundleKeyNamespace() {
+    val intKey = key("intKey").int(default = 2)
+    val nullableIntKey = key("nullableInt").int()
+    val requiredInt = key("requiredInt").int().asRequired()
+    val asyncRequiredInt = key("asyncRequiredInt").int().asRequired().asAsync()
+  }
+
+  private val savedStateHandle: SavedStateHandle = mock()
+
+  @Test fun testIntStateFlow() = runTest {
+    val backingStateFlow: MutableStateFlow<Int> = MutableStateFlow(Keys.intKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<Int>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int> = savedStateHandle.getStateFlow(this, Keys.intKey)
+
+      assertThat(result.value).isEqualTo(2)
+
+      result.test {
+        assertThat(awaitItem()).isEqualTo(2)
+
+        backingStateFlow.emit(10)
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test fun testNullableIntStateFlow() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.nullableIntKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.nullableIntKey)
+
+      assertThat(result.value).isNull()
+
+      result.test {
+        assertThat(awaitItem()).isNull()
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test fun testRequiredIntStateFlow_noValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.requiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    assertThat { savedStateHandle.getStateFlow(this, Keys.requiredInt) }
+      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+  }
+
+  @Test fun testRequiredIntStateFlow_hasValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.requiredInt)
+
+      assertThat(result.value).isEqualTo(5)
+
+      result.test {
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in othe coroutine
+  fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.asyncRequiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    val result = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
+    assertThat(result.value).isNull()
+    result.testIn(this)
+  }
+
+  @Test fun testRequiredAsyncIntStateFlow_hasValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
+
+      result.test {
+        assertThat(awaitItem()).isNull()
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+}

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
@@ -1,6 +1,7 @@
 package com.episode6.typed2.savedstatehandle
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
@@ -10,11 +11,14 @@ import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.asRequired
 import com.episode6.typed2.int
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.stub
+import org.mockito.kotlin.*
 
 class SavedStateHandleTest {
   object Keys : BundleKeyNamespace() {
@@ -63,4 +67,89 @@ class SavedStateHandleTest {
     assertThat { savedStateHandle.get(Keys.requiredInt) }
       .isFailure().hasClass(RequiredBundleKeyMissing::class)
   }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test fun testIntStateFlow() = runTest {
+    val backingStateFlow: MutableStateFlow<Int> = MutableStateFlow(Keys.intKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<Int>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int> = savedStateHandle.getStateFlow(this, Keys.intKey)
+
+      assertThat(result.value).isEqualTo(2)
+
+      result.test {
+        assertThat(awaitItem()).isEqualTo(2)
+
+        backingStateFlow.emit(10)
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test fun testNullableIntStateFlow() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.nullableIntKey.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.nullableIntKey)
+
+      assertThat(result.value).isNull()
+
+      result.test {
+        assertThat(awaitItem()).isNull()
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test fun testRequiredIntStateFlow_noValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.requiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    assertThat { savedStateHandle.getStateFlow(this, Keys.requiredInt) }
+      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test fun testRequiredIntStateFlow_hasValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.requiredInt)
+
+      assertThat(result.value).isEqualTo(5)
+
+      result.test {
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
 }
+
+

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
@@ -1,12 +1,16 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.episode6.typed2.savedstatehandle
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
+import app.cash.turbine.testIn
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.asAsync
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.asRequired
@@ -16,6 +20,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.*
@@ -25,6 +30,7 @@ class SavedStateHandleTest {
     val intKey = key("intKey").int(default = 2)
     val nullableIntKey = key("nullableInt").int()
     val requiredInt = key("requiredInt").int().asRequired()
+    val asyncRequiredInt = key("asyncRequiredInt").int().asRequired().asAsync()
   }
 
   private val savedStateHandle: SavedStateHandle = mock()
@@ -68,7 +74,6 @@ class SavedStateHandleTest {
       .isFailure().hasClass(RequiredBundleKeyMissing::class)
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   @Test fun testIntStateFlow() = runTest {
     val backingStateFlow: MutableStateFlow<Int> = MutableStateFlow(Keys.intKey.backingDefault())
     savedStateHandle.stub {
@@ -92,7 +97,6 @@ class SavedStateHandleTest {
     }
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   @Test fun testNullableIntStateFlow() = runTest {
     val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.nullableIntKey.backingDefault())
     savedStateHandle.stub {
@@ -116,7 +120,6 @@ class SavedStateHandleTest {
     }
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   @Test fun testRequiredIntStateFlow_noValue() = runTest {
     val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.requiredInt.backingDefault())
     savedStateHandle.stub {
@@ -127,7 +130,6 @@ class SavedStateHandleTest {
       .isFailure().hasClass(RequiredBundleKeyMissing::class)
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
   @Test fun testRequiredIntStateFlow_hasValue() = runTest {
     val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
     savedStateHandle.stub {
@@ -140,6 +142,40 @@ class SavedStateHandleTest {
       assertThat(result.value).isEqualTo(5)
 
       result.test {
+        assertThat(awaitItem()).isEqualTo(5)
+
+        backingStateFlow.emit("10")
+
+        assertThat(awaitItem()).isEqualTo(10)
+      }
+
+      cancel()
+    }
+  }
+
+  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in othe coroutine
+  fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.asyncRequiredInt.backingDefault())
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    val result = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
+    assertThat(result.value).isNull()
+    result.testIn(this)
+  }
+
+  @Test fun testRequiredAsyncIntStateFlow_hasValue() = runTest {
+    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
+    savedStateHandle.stub {
+      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
+    }
+
+    launch {
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
+
+      result.test {
+        assertThat(awaitItem()).isNull()
         assertThat(awaitItem()).isEqualTo(5)
 
         backingStateFlow.emit("10")

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
@@ -1,10 +1,6 @@
-@file:OptIn(ExperimentalCoroutinesApi::class)
-
 package com.episode6.typed2.savedstatehandle
 
 import androidx.lifecycle.SavedStateHandle
-import app.cash.turbine.test
-import app.cash.turbine.testIn
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
@@ -15,15 +11,11 @@ import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.asRequired
 import com.episode6.typed2.int
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import org.mockito.kotlin.*
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
 
 class SavedStateHandleTest {
   object Keys : BundleKeyNamespace() {
@@ -72,119 +64,6 @@ class SavedStateHandleTest {
 
     assertThat { savedStateHandle.get(Keys.requiredInt) }
       .isFailure().hasClass(RequiredBundleKeyMissing::class)
-  }
-
-  @Test fun testIntStateFlow() = runTest {
-    val backingStateFlow: MutableStateFlow<Int> = MutableStateFlow(Keys.intKey.backingDefault())
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<Int>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    launch {
-      val result: StateFlow<Int> = savedStateHandle.getStateFlow(this, Keys.intKey)
-
-      assertThat(result.value).isEqualTo(2)
-
-      result.test {
-        assertThat(awaitItem()).isEqualTo(2)
-
-        backingStateFlow.emit(10)
-
-        assertThat(awaitItem()).isEqualTo(10)
-      }
-
-      cancel()
-    }
-  }
-
-  @Test fun testNullableIntStateFlow() = runTest {
-    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.nullableIntKey.backingDefault())
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    launch {
-      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.nullableIntKey)
-
-      assertThat(result.value).isNull()
-
-      result.test {
-        assertThat(awaitItem()).isNull()
-
-        backingStateFlow.emit("10")
-
-        assertThat(awaitItem()).isEqualTo(10)
-      }
-
-      cancel()
-    }
-  }
-
-  @Test fun testRequiredIntStateFlow_noValue() = runTest {
-    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.requiredInt.backingDefault())
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    assertThat { savedStateHandle.getStateFlow(this, Keys.requiredInt) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
-  }
-
-  @Test fun testRequiredIntStateFlow_hasValue() = runTest {
-    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    launch {
-      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.requiredInt)
-
-      assertThat(result.value).isEqualTo(5)
-
-      result.test {
-        assertThat(awaitItem()).isEqualTo(5)
-
-        backingStateFlow.emit("10")
-
-        assertThat(awaitItem()).isEqualTo(10)
-      }
-
-      cancel()
-    }
-  }
-
-  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in othe coroutine
-  fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
-    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.asyncRequiredInt.backingDefault())
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    val result = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
-    assertThat(result.value).isNull()
-    result.testIn(this)
-  }
-
-  @Test fun testRequiredAsyncIntStateFlow_hasValue() = runTest {
-    val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow("5")
-    savedStateHandle.stub {
-      onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
-    }
-
-    launch {
-      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(this, Keys.asyncRequiredInt)
-
-      result.test {
-        assertThat(awaitItem()).isNull()
-        assertThat(awaitItem()).isEqualTo(5)
-
-        backingStateFlow.emit("10")
-
-        assertThat(awaitItem()).isEqualTo(10)
-      }
-
-      cancel()
-    }
   }
 }
 


### PR DESCRIPTION
This kinda sucks because before this a `Key` was kind of simple and elegant with only get & set methods. However if we want to support the stateFlow and liveData methods in SavedStateHandle, we need to split up & capture the backing data type (this should also be useful for supporting the compose nav case down the road).

Steps:
 - Add `BACKED_BY: Any?` type to Key and AsyncKey
 - Split keys' get & set into getBackingData & mapGet + setBackingData & mapSet
 - add generic method to create a `NativeKey` which is just any Key where types `T === BACKED_BY`
 - add support for new methods on saveStateHandle leveraging mapGet & mapSet 

Piggyback: As an optimization, we make Key a data class (we can haz generic data classes now, yay). If we revert this PR we should keep this change.