### PR TITLE
Synchronize syntax for default providers in gson & json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Example:
 object PrefKeys : PrefKeyNamespace(prefix = "com.sample.prefkey.") {
   val SOME_INT = key("someInt").int(default = 2)
   val SOME_NULLABLE_INT = key("nullableInt").int()
-  val SOME_SERIALIZED_OBJECT = key("myObj").json(SomeObject.serializer()).async()
+  val SOME_KOTLINX_SERIALIZED_OBJECT = key("myObj").json(SomeObject::serializer).async()
+  val SOME_GSON_SERIALIZED_OBJECT = key("myObj2").gson<SomeOtherObject>(default = SomeOtherObject()).async()
 }
 
 val sharedPreferences: SharedPreference = TODO()
@@ -20,6 +21,7 @@ fun main() {
   val someNullableInt: Int? = sharedPreferences.get(PrefKeys.SOME_NULLABLE_INT)
   coroutineContext {
     val someObject: SomeObject? = sharedPreferences.get(PrefKeys.SOME_SERIALIZED_OBJECT)
+    val someOtherObject: SomeOtherObject? = sharedPreferences.get(PrefKeys.SOME_GSON_SERIALIZED_OBJECT)
   }
 }
 ```

--- a/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
+++ b/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
@@ -5,19 +5,19 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
 object Typed2DefaultGson {
-  private val default: Gson by lazy(LazyThreadSafetyMode.PUBLICATION) { Gson() }
+  private val default: Gson by lazy { Gson() }
   fun gson(): Gson = default
 }
 
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   default: T,
   noinline gson: () -> Gson = Typed2DefaultGson::gson,
-): PrimitiveKey<T, String?> = gson<T>(gson).withDefault { default }
+): PrimitiveKey<T, String?> = gson<T>(defaultProvider = { default }, gson)
 
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
+  noinline defaultProvider: () -> T,
   noinline gson: () -> Gson = Typed2DefaultGson::gson,
-  noinline default: ()->T,
-): PrimitiveKey<T, String?> = gson<T>(gson).withDefault(default)
+): PrimitiveKey<T, String?> = gson<T>(gson).withDefault(defaultProvider)
 
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   noinline gson: () -> Gson = Typed2DefaultGson::gson,

--- a/gson/src/test/kotlin/com/episode6/typed2/gson/GsonSerializedKeyTest.kt
+++ b/gson/src/test/kotlin/com/episode6/typed2/gson/GsonSerializedKeyTest.kt
@@ -22,7 +22,6 @@ class JsonSerializedKeyTest {
     val nullableData = key("testData").gson<TestData>()
     val defaultData = key("withDefault").gson(default = TestData("default"))
     val requiredData = key("required").gson<TestData>().required()
-    val something = key("name").gson(default = { TestData("") }).async()
   }
 
   private val bundle: Bundle = mock()

--- a/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
+++ b/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
@@ -6,20 +6,20 @@ import kotlinx.serialization.json.Json
 
 fun <T : Any> PrimitiveKeyBuilder.json(
   default: T,
-  serializer: KSerializer<T>,
+  serializer: ()->KSerializer<T>,
   json: Json = Json,
-): PrimitiveKey<T, String?> = json(serializer, json) { default }
+): PrimitiveKey<T, String?> = json(defaultProvider = { default }, serializer, json)
 
 fun <T : Any> PrimitiveKeyBuilder.json(
-  serializer: KSerializer<T>,
+  defaultProvider: () -> T,
+  serializer: ()->KSerializer<T>,
   json: Json = Json,
-  default: () -> T,
-): PrimitiveKey<T, String?> = json(serializer, json).withDefault(default)
+): PrimitiveKey<T, String?> = json(serializer, json).withDefault(defaultProvider)
 
 fun <T : Any> PrimitiveKeyBuilder.json(
-  serializer: KSerializer<T>,
+  serializer: ()->KSerializer<T>,
   json: Json = Json,
 ): PrimitiveKey<T?, String?> = string().mapType(
-  mapGet = { it?.let { json.decodeFromString(serializer, it) } },
-  mapSet = { it?.let { json.encodeToString(serializer, it) } }
+  mapGet = { it?.let { json.decodeFromString(serializer(), it) } },
+  mapSet = { it?.let { json.encodeToString(serializer(), it) } }
 )

--- a/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
+++ b/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
@@ -6,20 +6,20 @@ import kotlinx.serialization.json.Json
 
 fun <T : Any> PrimitiveKeyBuilder.json(
   default: T,
-  serializer: ()->KSerializer<T>,
-  json: Json = Json,
+  serializer: () -> KSerializer<T>,
+  json: () -> Json = { Json },
 ): PrimitiveKey<T, String?> = json(defaultProvider = { default }, serializer, json)
 
 fun <T : Any> PrimitiveKeyBuilder.json(
   defaultProvider: () -> T,
-  serializer: ()->KSerializer<T>,
-  json: Json = Json,
+  serializer: () -> KSerializer<T>,
+  json: () -> Json = { Json },
 ): PrimitiveKey<T, String?> = json(serializer, json).withDefault(defaultProvider)
 
 fun <T : Any> PrimitiveKeyBuilder.json(
-  serializer: ()->KSerializer<T>,
-  json: Json = Json,
+  serializer: () -> KSerializer<T>,
+  json: () -> Json = { Json },
 ): PrimitiveKey<T?, String?> = string().mapType(
-  mapGet = { it?.let { json.decodeFromString(serializer(), it) } },
-  mapSet = { it?.let { json.encodeToString(serializer(), it) } }
+  mapGet = { it?.let { json().decodeFromString(serializer(), it) } },
+  mapSet = { it?.let { json().encodeToString(serializer(), it) } }
 )

--- a/kotlinx-serialization-json/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeyTest.kt
+++ b/kotlinx-serialization-json/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeyTest.kt
@@ -19,9 +19,9 @@ import org.mockito.kotlin.verify
 class JsonSerializedKeyTest {
 
   object Keys : BundleKeyNamespace() {
-    val nullableData = key("testData").json(TestData.serializer())
-    val defaultData = key("withDefault").json(default = TestData("default"), TestData.serializer())
-    val requiredData = key("required").json(TestData.serializer()).required()
+    val nullableData = key("testData").json(TestData::serializer)
+    val defaultData = key("withDefault").json(default = TestData("default"), TestData::serializer)
+    val requiredData = key("required").json(TestData::serializer).required()
   }
 
   private val bundle: Bundle = mock()


### PR DESCRIPTION
Use an alt param name for default providers so we can keep out syntax consistent.