### PR TITLE
Ditch the native key typealiases

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -4,14 +4,13 @@ import java.math.BigDecimal
 
 typealias PrimitiveKey<T, BACKED_BY> = Key<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
 typealias AsyncPrimitiveKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
-typealias NativePrimitiveKey<T> = PrimitiveKey<T, T>
 
 interface PrimitiveKeyBuilder : KeyBuilder {
   fun String.encode(): String = this
   fun String.decode(): String = this
 }
 
-fun PrimitiveKeyBuilder.boolean(default: Boolean): NativePrimitiveKey<Boolean> = nativeKey(
+fun PrimitiveKeyBuilder.boolean(default: Boolean): PrimitiveKey<Boolean, Boolean> = nativeKey(
   get = { getBoolean(name, default) },
   set = { setBoolean(name, it) },
   backingDefault = default
@@ -22,7 +21,7 @@ fun PrimitiveKeyBuilder.boolean(): PrimitiveKey<Boolean?, String?> = string().ma
   mapSet = { it?.toString() }
 )
 
-fun PrimitiveKeyBuilder.float(default: Float): NativePrimitiveKey<Float> = nativeKey(
+fun PrimitiveKeyBuilder.float(default: Float): PrimitiveKey<Float, Float> = nativeKey(
   get = { getFloat(name, default) },
   set = { setFloat(name, it) },
   backingDefault = default
@@ -33,7 +32,7 @@ fun PrimitiveKeyBuilder.float(): PrimitiveKey<Float?, String?> = string().mapTyp
   mapSet = { it?.toString() }
 )
 
-fun PrimitiveKeyBuilder.int(default: Int): NativePrimitiveKey<Int> = nativeKey(
+fun PrimitiveKeyBuilder.int(default: Int): PrimitiveKey<Int, Int> = nativeKey(
   get = { getInt(name, default) },
   set = { setInt(name, it) },
   backingDefault = default
@@ -44,7 +43,7 @@ fun PrimitiveKeyBuilder.int(): PrimitiveKey<Int?, String?> = string().mapType(
   mapSet = { it?.toString() }
 )
 
-fun PrimitiveKeyBuilder.long(default: Long): NativePrimitiveKey<Long> = nativeKey(
+fun PrimitiveKeyBuilder.long(default: Long): PrimitiveKey<Long, Long> = nativeKey(
   get = { getLong(name, default) },
   set = { setLong(name, it) },
   backingDefault = default
@@ -55,7 +54,7 @@ fun PrimitiveKeyBuilder.long(): PrimitiveKey<Long?, String?> = string().mapType(
   mapSet = { it?.toString() }
 )
 
-fun PrimitiveKeyBuilder.string(default: String): NativePrimitiveKey<String> =
+fun PrimitiveKeyBuilder.string(default: String): PrimitiveKey<String, String> =
   nativeKey<String, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>(
     get = { getString(name, default) ?: default },
     set = { setString(name, it) },
@@ -65,7 +64,7 @@ fun PrimitiveKeyBuilder.string(default: String): NativePrimitiveKey<String> =
     mapSet = { it.encode() },
   )
 
-fun PrimitiveKeyBuilder.string(): NativePrimitiveKey<String?> =
+fun PrimitiveKeyBuilder.string(): PrimitiveKey<String?, String?> =
   nativeKey<String, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>(
     get = { getString(name, null) },
     set = { setString(name, it) },

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -6,8 +6,6 @@ import kotlin.coroutines.CoroutineContext
 
 typealias BaseBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, in BaseBundleValueGetter, in BaseBundleValueSetter>
 typealias AsyncBaseBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in BaseBundleValueGetter, in BaseBundleValueSetter>
-typealias NativeBaseBundleKey<T> = BaseBundleKey<T, T>
-typealias NativeAsyncBaseBundleKey<T> = AsyncBaseBundleKey<T, T>
 
 interface BaseBundleKeyBuilder : PrimitiveKeyBuilder
 
@@ -24,7 +22,7 @@ open class BaseBundleKeyNamespace(private val prefix: String = "") {
   protected fun <T : Any?, BACKED_BY : Any?> BaseBundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncBaseBundleKey<T, BACKED_BY> = asAsync(context)
 }
 
-fun BaseBundleKeyBuilder.double(default: Double): NativeBaseBundleKey<Double> = nativeKey(
+fun BaseBundleKeyBuilder.double(default: Double): BaseBundleKey<Double, Double> = nativeKey(
   get = { getDouble(name, default) },
   set = { setDouble(name, default) },
   backingDefault = default,

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -7,8 +7,6 @@ import kotlin.coroutines.CoroutineContext
 
 typealias PersistableBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
 typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
-typealias NativePersistableBundleKey<T> = PersistableBundleKey<T, T>
-typealias NativeAsyncPersistableBundleKey<T> = AsyncPersistableBundleKey<T, T>
 typealias PersistableBundleProperty<T> = KeyValueDelegate<T, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
 
 interface PersistableBundleKeyBuilder : BaseBundleKeyBuilder
@@ -22,7 +20,7 @@ open class PersistableBundleKeyNamespace(private val prefix: String = "") {
 
 fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle { default }
 fun PersistableBundleKeyBuilder.persistableBundle(default: () -> PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle().withDefault(default)
-fun PersistableBundleKeyBuilder.persistableBundle(): NativePersistableBundleKey<PersistableBundle?> = nativeKey(
+fun PersistableBundleKeyBuilder.persistableBundle(): PersistableBundleKey<PersistableBundle?, PersistableBundle?> = nativeKey(
   get = { getPersistableBundle(name) },
   set = { setPersistableBundle(name, it) },
 )

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -6,8 +6,6 @@ import kotlin.coroutines.CoroutineContext
 
 typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, in PrefValueGetter, in PrefValueSetter>
 typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrefValueGetter, in PrefValueSetter>
-typealias NativePrefKey<T> = PrefKey<T, T>
-typealias NativeAsyncPrefKey<T> = AsyncPrefKey<T, T>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
 open class PrefKeyNamespace(private val prefix: String = "") {
@@ -28,7 +26,7 @@ fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableS
   mapSet = { it }
 )
 
-fun PrefKeyBuilder.nullableStringSet(): NativePrefKey<Set<String?>?> = nativeKey(
+fun PrefKeyBuilder.nullableStringSet(): PrefKey<Set<String?>?, Set<String?>?> = nativeKey(
   get = { getStringSet(name, null) },
   set = { setStringSet(name, it) },
 )

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -7,8 +7,6 @@ import kotlin.coroutines.CoroutineContext
 
 typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
 typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
-typealias NativeNavArg<T> = NavArg<T, T>
-typealias NativeAsyncNavArg<T> = AsyncNavArg<T, T>
 
 interface NavArgBuilder : PrimitiveKeyBuilder
 open class NavScreen(val name: String, private val argPrefix: String = "") {


### PR DESCRIPTION
I've been thinking that the native key type aliases just add to confusion even though they can reduce a bit of repetition. Ditching them and instead always listing both T and BACKED_BY in method signatures