### PR TITLE
Drop key creators that take providers as defaults

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -18,6 +18,7 @@ open class BaseBundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BaseBundleKeyBuilder = Builder(prefix + name)
 
+  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.default(default: ()->T): BaseBundleKey<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.required(): BaseBundleKey<T, BACKED_BY> = asRequired { RequiredBaseBundleKeyMissing(name) }
   protected fun <T : Any?, BACKED_BY : Any?> BaseBundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncBaseBundleKey<T, BACKED_BY> = asAsync(context)
 }

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -16,6 +16,7 @@ open class BundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
 
+  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.default(default: ()->T): BundleKey<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.required(): BundleKey<T, BACKED_BY> = asRequired { RequiredBundleKeyMissing(name) }
   protected fun <T : Any?, BACKED_BY : Any?> BundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncBundleKey<T, BACKED_BY> = asAsync(context)
 }
@@ -26,8 +27,7 @@ fun <T : IBinder> BundleKeyBuilder.binder(safeCast: Boolean = false): BundleKey<
   mapSet = { it }
 )
 
-fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle { default }
-fun BundleKeyBuilder.bundle(default: () -> Bundle): BundleKey<Bundle, Bundle?> = bundle().withDefault(default)
+fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle().withDefault { default }
 fun BundleKeyBuilder.bundle(): BundleKey<Bundle?, Bundle?> = nativeKey(
   get = { getBundle(name) },
   set = { setBundle(name, it) },
@@ -44,8 +44,7 @@ fun BundleKeyBuilder.byte(): BundleKey<Byte?, String?> = int().mapType(
   mapSet = { it?.toInt() }
 )
 
-fun BundleKeyBuilder.byteArray(default: ByteArray): BundleKey<ByteArray, ByteArray?> = byteArray { default }
-fun BundleKeyBuilder.byteArray(default: ()->ByteArray): BundleKey<ByteArray, ByteArray?> = byteArray().withDefault(default)
+fun BundleKeyBuilder.byteArray(default: ByteArray): BundleKey<ByteArray, ByteArray?> = byteArray().withDefault { default }
 fun BundleKeyBuilder.byteArray(): BundleKey<ByteArray?, ByteArray?> = nativeKey(
   get = { getByteArray(name) },
   set = { setByteArray(name, it) }
@@ -62,29 +61,25 @@ fun BundleKeyBuilder.char(): BundleKey<Char?, String?> = string().mapType(
   mapSet = { it?.toString() }
 )
 
-fun BundleKeyBuilder.charArray(default: CharArray): BundleKey<CharArray, CharArray?> = charArray { default }
-fun BundleKeyBuilder.charArray(default: ()->CharArray): BundleKey<CharArray, CharArray?> = charArray().withDefault(default)
+fun BundleKeyBuilder.charArray(default: CharArray): BundleKey<CharArray, CharArray?> = charArray().withDefault { default }
 fun BundleKeyBuilder.charArray(): BundleKey<CharArray?, CharArray?> = nativeKey(
   get = { getCharArray(name) },
   set = { setCharArray(name, it) }
 )
 
-fun BundleKeyBuilder.charSequence(default: CharSequence): BundleKey<CharSequence, CharSequence?> = charSequence { default }
-fun BundleKeyBuilder.charSequence(default: ()->CharSequence): BundleKey<CharSequence, CharSequence?> = charSequence().withDefault(default)
+fun BundleKeyBuilder.charSequence(default: CharSequence): BundleKey<CharSequence, CharSequence?> = charSequence().withDefault { default }
 fun BundleKeyBuilder.charSequence(): BundleKey<CharSequence?, CharSequence?> = nativeKey(
   get = { getCharSequence(name) },
   set = { setCharSequence(name, it) }
 )
 
-fun BundleKeyBuilder.charSequenceArray(default: Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> = charSequenceArray { default }
-fun BundleKeyBuilder.charSequenceArray(default: ()->Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> = charSequenceArray().withDefault(default)
+fun BundleKeyBuilder.charSequenceArray(default: Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> = charSequenceArray().withDefault { default }
 fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<CharSequence>?> = nativeKey(
   get = { getCharSequenceArray(name) },
   set = { setCharSequenceArray(name, it) }
 )
 
-fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList { default }
-fun BundleKeyBuilder.charSequenceList(default: ()->List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList().withDefault(default)
+fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList().withDefault { default }
 fun BundleKeyBuilder.charSequenceList(): BundleKey<List<CharSequence>?, ArrayList<CharSequence>?> = charSequenceArrayList().mapType(
   mapGet = { it },
   mapSet = { it?.let { if (it is ArrayList<CharSequence>) it else ArrayList(it) } },

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -14,12 +14,12 @@ open class PersistableBundleKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PersistableBundleKeyBuilder
 
   protected fun key(name: String): PersistableBundleKeyBuilder = Builder(prefix + name)
+  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.default(default: ()->T): PersistableBundleKey<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.required(): PersistableBundleKey<T, BACKED_BY> = asRequired { RequiredPersistableBundleKeyMissing(name) }
   protected fun <T : Any?, BACKED_BY : Any?> PersistableBundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncPersistableBundleKey<T, BACKED_BY> = asAsync(context)
 }
 
-fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle { default }
-fun PersistableBundleKeyBuilder.persistableBundle(default: () -> PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle().withDefault(default)
+fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle().withDefault { default }
 fun PersistableBundleKeyBuilder.persistableBundle(): PersistableBundleKey<PersistableBundle?, PersistableBundle?> = nativeKey(
   get = { getPersistableBundle(name) },
   set = { setPersistableBundle(name, it) },

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -12,15 +12,13 @@ open class PrefKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PrefKeyBuilder
 
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)
+  protected fun <T : Any, BACKED_BY: Any> PrefKey<T?, BACKED_BY>.default(default: ()->T): PrefKey<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any?, BACKED_BY : Any?> PrefKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncPrefKey<T, BACKED_BY> = asAsync(context)
 }
 
 fun PrefKeyBuilder.double(default: Double): PrefKey<Double, String?> = double().withDefault { default }
 
-fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet { default }
-fun PrefKeyBuilder.stringSet(default: () -> Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet()
-  .withDefault(default)
-
+fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().withDefault { default }
 fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }

--- a/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
+++ b/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
@@ -12,12 +12,7 @@ object Typed2DefaultGson {
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   default: T,
   noinline gson: () -> Gson = Typed2DefaultGson::gson,
-): PrimitiveKey<T, String?> = gson<T>(defaultProvider = { default }, gson)
-
-inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
-  noinline defaultProvider: () -> T,
-  noinline gson: () -> Gson = Typed2DefaultGson::gson,
-): PrimitiveKey<T, String?> = gson<T>(gson).withDefault(defaultProvider)
+): PrimitiveKey<T, String?> = gson<T>(gson).withDefault { default }
 
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   noinline gson: () -> Gson = Typed2DefaultGson::gson,

--- a/kotlinx-serialization-bundlizer/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeys.kt
+++ b/kotlinx-serialization-bundlizer/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeys.kt
@@ -13,12 +13,7 @@ import kotlinx.serialization.KSerializer
 fun <T : Any> BundleKeyBuilder.bundlized(
   default: T,
   serializer: () -> KSerializer<T>,
-): BundleKey<T, Bundle?> = bundlized(defaultProvider = { default }, serializer)
-
-fun <T : Any> BundleKeyBuilder.bundlized(
-  defaultProvider: () -> T,
-  serializer: () -> KSerializer<T>,
-): BundleKey<T, Bundle?> = bundlized(serializer).withDefault(defaultProvider)
+): BundleKey<T, Bundle?> = bundlized(serializer).withDefault { default }
 
 fun <T : Any> BundleKeyBuilder.bundlized(
   serializer: () -> KSerializer<T>,

--- a/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
+++ b/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
@@ -8,13 +8,7 @@ fun <T : Any> PrimitiveKeyBuilder.json(
   default: T,
   serializer: () -> KSerializer<T>,
   json: () -> Json = { Json },
-): PrimitiveKey<T, String?> = json(defaultProvider = { default }, serializer, json)
-
-fun <T : Any> PrimitiveKeyBuilder.json(
-  defaultProvider: () -> T,
-  serializer: () -> KSerializer<T>,
-  json: () -> Json = { Json },
-): PrimitiveKey<T, String?> = json(serializer, json).withDefault(defaultProvider)
+): PrimitiveKey<T, String?> = json(serializer, json).withDefault { default }
 
 fun <T : Any> PrimitiveKeyBuilder.json(
   serializer: () -> KSerializer<T>,

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -23,6 +23,7 @@ open class NavScreen(val name: String, private val argPrefix: String = "") {
   }
 
   protected fun key(name: String): NavArgBuilder = Builder(argPrefix + name) { _args[it.name] = it }
+  protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.default(default: ()->T): NavArg<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.required(): NavArg<T, BACKED_BY> = asRequired { RequiredNavArgumentMissing(name) }
   protected fun <T : Any?, BACKED_BY : Any?> NavArg<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncNavArg<T, BACKED_BY> = asAsync(context)
 }


### PR DESCRIPTION
Add `.default {}` method to all namespaces instead