### PR TITLE
Apply `in` to getter & setter type param of Key and AsyncKey

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
@@ -5,7 +5,7 @@ class AsyncKeyMapper<T : Any?, BACKED_BY : Any?> internal constructor(
   val mapSet: suspend (T) -> BACKED_BY,
 )
 
-class AsyncKey<T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> internal constructor(
+class AsyncKey<T : Any?, BACKED_BY : Any?, in GETTER : KeyValueGetter, in SETTER : KeyValueSetter> internal constructor(
   override val name: String,
   override val outputDefault: OutputDefault<T>?,
   override val backingTypeInfo: KeyBackingTypeInfo<BACKED_BY>,

--- a/core/src/main/kotlin/com/episode6/typed2/Key.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/Key.kt
@@ -1,6 +1,6 @@
 package com.episode6.typed2
 
-class KeyBacker<BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> internal constructor(
+class KeyBacker<BACKED_BY : Any?, in GETTER : KeyValueGetter, in SETTER : KeyValueSetter> internal constructor(
   val getBackingData: (GETTER) -> BACKED_BY,
   val setBackingData: (SETTER, BACKED_BY) -> Unit,
 )
@@ -10,7 +10,7 @@ class KeyMapper<T : Any?, BACKED_BY : Any?> internal constructor(
   val mapSet: (T) -> BACKED_BY,
 )
 
-class Key<T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> internal constructor(
+class Key<T : Any?, BACKED_BY : Any?, in GETTER : KeyValueGetter, in SETTER : KeyValueSetter> internal constructor(
   override val name: String,
   override val outputDefault: OutputDefault<T>?,
   override val backingTypeInfo: KeyBackingTypeInfo<BACKED_BY>,

--- a/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
@@ -1,5 +1,6 @@
 package com.episode6.typed2
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
@@ -41,18 +42,18 @@ fun <T : Any?, R : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : Key
   newKeyCallback = newKeyCallback,
 )
 
-fun <T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, BACKED_BY, GETTER, SETTER>.asAsync(
-  context: CoroutineContext,
+fun <T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, BACKED_BY, GETTER, SETTER>.async(
+  context: CoroutineContext = Dispatchers.Default,
 ): AsyncKey<T, BACKED_BY, GETTER, SETTER> = AsyncKey(
   name = name,
   outputDefault = outputDefault,
   backingTypeInfo = backingTypeInfo,
   backer = backer,
-  mapper = mapper.asAsync(context),
+  mapper = mapper.async(context),
   newKeyCallback = newKeyCallback,
 )
 
-private fun <T : Any?, BACKED_BY : Any?> KeyMapper<T, BACKED_BY>.asAsync(context: CoroutineContext) =
+private fun <T : Any?, BACKED_BY : Any?> KeyMapper<T, BACKED_BY>.async(context: CoroutineContext) =
   AsyncKeyMapper<T, BACKED_BY>(
     mapGet = { withContext(context) { mapGet(it) } },
     mapSet = { withContext(context) { mapSet(it) } },

--- a/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
@@ -9,7 +9,7 @@ fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter
   default: () -> T,
 ): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Provider(default))
 
-fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.asRequired(
+internal fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.asRequired(
   doesNotExistError: () -> Throwable,
 ): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Required(doesNotExistError))
 

--- a/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
@@ -9,11 +9,7 @@ fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter
   default: () -> T,
 ): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Provider(default))
 
-internal fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.asRequired(
-  doesNotExistError: () -> Throwable,
-): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Required(doesNotExistError))
-
-private fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.withOutputDefault(
+internal fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.withOutputDefault(
   default: OutputDefault<T>,
 ): Key<T, BACKED_BY, GETTER, SETTER> = Key(
   name = name,

--- a/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 
-fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.withDefault(
+fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.defaultProvider(
   default: () -> T,
 ): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Provider(default))
 

--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeys.kt
@@ -2,8 +2,8 @@ package com.episode6.typed2
 
 import java.math.BigDecimal
 
-typealias PrimitiveKey<T, BACKED_BY> = Key<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
-typealias AsyncPrimitiveKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
+typealias PrimitiveKey<T, BACKED_BY> = Key<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
+typealias AsyncPrimitiveKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
 
 interface PrimitiveKeyBuilder : KeyBuilder {
   fun String.encode(): String = this

--- a/core/src/main/kotlin/com/episode6/typed2/RequiredEnabledKeyNamespace.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/RequiredEnabledKeyNamespace.kt
@@ -1,0 +1,9 @@
+package com.episode6.typed2
+
+interface RequiredEnabledKeyNamespace {
+  fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.required(
+    doesNotExistError: () -> Throwable = { RequiredKeyMissingException(name) }
+  ): Key<T, BACKED_BY, GETTER, SETTER> = asRequired(doesNotExistError)
+}
+
+class RequiredKeyMissingException(name: String) : RuntimeException("Required key ($name) missing from typed2 key-value store")

--- a/core/src/main/kotlin/com/episode6/typed2/RequiredEnabledKeyNamespace.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/RequiredEnabledKeyNamespace.kt
@@ -3,7 +3,7 @@ package com.episode6.typed2
 interface RequiredEnabledKeyNamespace {
   fun <T : Any, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T?, BACKED_BY, GETTER, SETTER>.required(
     doesNotExistError: () -> Throwable = { RequiredKeyMissingException(name) }
-  ): Key<T, BACKED_BY, GETTER, SETTER> = asRequired(doesNotExistError)
+  ): Key<T, BACKED_BY, GETTER, SETTER> = withOutputDefault(OutputDefault.Required(doesNotExistError))
 }
 
 class RequiredKeyMissingException(name: String) : RuntimeException("Required key ($name) missing from typed2 key-value store")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -16,9 +16,6 @@ open class BaseBundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BaseBundleKeyBuilder = Builder(prefix + name)
 
-  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.default(default: () -> T): BaseBundleKey<T, BACKED_BY> =
-    withDefault(default)
-
   protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.required(): BaseBundleKey<T, BACKED_BY> =
     asRequired { RequiredBaseBundleKeyMissing(name) }
 }

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -1,6 +1,7 @@
 package com.episode6.typed2.bundles
 
 import com.episode6.typed2.*
+import com.episode6.typed2.nativeKey
 
 typealias BaseBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
 typealias AsyncBaseBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
@@ -11,13 +12,10 @@ interface BaseBundleKeyBuilder : PrimitiveKeyBuilder
  * This namespace should only be needed if you want to explicitly declare a set of keys
  * that can be shared between Bundle & PersistableBundle.
  */
-open class BaseBundleKeyNamespace(private val prefix: String = "") {
+open class BaseBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
   private class Builder(override val name: String) : BaseBundleKeyBuilder
 
   protected fun key(name: String): BaseBundleKeyBuilder = Builder(prefix + name)
-
-  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.required(): BaseBundleKey<T, BACKED_BY> =
-    asRequired { RequiredBaseBundleKeyMissing(name) }
 }
 
 fun BaseBundleKeyBuilder.double(default: Double): BaseBundleKey<Double, Double> = nativeKey(
@@ -25,5 +23,3 @@ fun BaseBundleKeyBuilder.double(default: Double): BaseBundleKey<Double, Double> 
   set = { setDouble(name, default) },
   backingDefault = default,
 )
-
-class RequiredBaseBundleKeyMissing(name: String) : IllegalArgumentException("Required key ($name) missing from BaseBundle")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -1,8 +1,6 @@
 package com.episode6.typed2.bundles
 
 import com.episode6.typed2.*
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
 
 typealias BaseBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
 typealias AsyncBaseBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
@@ -18,9 +16,11 @@ open class BaseBundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BaseBundleKeyBuilder = Builder(prefix + name)
 
-  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.default(default: ()->T): BaseBundleKey<T, BACKED_BY> = withDefault(default)
-  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.required(): BaseBundleKey<T, BACKED_BY> = asRequired { RequiredBaseBundleKeyMissing(name) }
-  protected fun <T : Any?, BACKED_BY : Any?> BaseBundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncBaseBundleKey<T, BACKED_BY> = asAsync(context)
+  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.default(default: () -> T): BaseBundleKey<T, BACKED_BY> =
+    withDefault(default)
+
+  protected fun <T : Any, BACKED_BY : Any?> BaseBundleKey<T?, BACKED_BY>.required(): BaseBundleKey<T, BACKED_BY> =
+    asRequired { RequiredBaseBundleKeyMissing(name) }
 }
 
 fun BaseBundleKeyBuilder.double(default: Double): BaseBundleKey<Double, Double> = nativeKey(

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -4,8 +4,8 @@ import com.episode6.typed2.*
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-typealias BaseBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, in BaseBundleValueGetter, in BaseBundleValueSetter>
-typealias AsyncBaseBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in BaseBundleValueGetter, in BaseBundleValueSetter>
+typealias BaseBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
+typealias AsyncBaseBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BaseBundleValueGetter, BaseBundleValueSetter>
 
 interface BaseBundleKeyBuilder : PrimitiveKeyBuilder
 

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -9,13 +9,10 @@ typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BundleValueGette
 typealias BundleProperty<T> = KeyValueDelegate<T, in BundleValueGetter, in BundleValueSetter>
 
 interface BundleKeyBuilder : BaseBundleKeyBuilder
-open class BundleKeyNamespace(private val prefix: String = "") {
+open class BundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
   private class Builder(override val name: String) : BundleKeyBuilder
 
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
-
-  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.required(): BundleKey<T, BACKED_BY> =
-    asRequired { RequiredBundleKeyMissing(name) }
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -95,5 +92,3 @@ private fun BundleKeyBuilder.charSequenceArrayList(): BundleKey<ArrayList<CharSe
   get = { getCharSequenceArrayList(name) },
   set = { setCharSequenceArrayList(name, it) }
 )
-
-class RequiredBundleKeyMissing(name: String) : IllegalArgumentException("Required key ($name) missing from bundle")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -14,9 +14,6 @@ open class BundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
 
-  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.default(default: () -> T): BundleKey<T, BACKED_BY> =
-    withDefault(default)
-
   protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.required(): BundleKey<T, BACKED_BY> =
     asRequired { RequiredBundleKeyMissing(name) }
 }
@@ -27,7 +24,7 @@ fun <T : IBinder> BundleKeyBuilder.binder(safeCast: Boolean = false): BundleKey<
   mapSet = { it }
 )
 
-fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle().withDefault { default }
+fun BundleKeyBuilder.bundle(default: Bundle): BundleKey<Bundle, Bundle?> = bundle().defaultProvider { default }
 fun BundleKeyBuilder.bundle(): BundleKey<Bundle?, Bundle?> = nativeKey(
   get = { getBundle(name) },
   set = { setBundle(name, it) },
@@ -44,7 +41,7 @@ fun BundleKeyBuilder.byte(): BundleKey<Byte?, String?> = int().mapType(
   mapSet = { it?.toInt() }
 )
 
-fun BundleKeyBuilder.byteArray(default: ByteArray): BundleKey<ByteArray, ByteArray?> = byteArray().withDefault { default }
+fun BundleKeyBuilder.byteArray(default: ByteArray): BundleKey<ByteArray, ByteArray?> = byteArray().defaultProvider { default }
 fun BundleKeyBuilder.byteArray(): BundleKey<ByteArray?, ByteArray?> = nativeKey(
   get = { getByteArray(name) },
   set = { setByteArray(name, it) }
@@ -61,20 +58,20 @@ fun BundleKeyBuilder.char(): BundleKey<Char?, String?> = string().mapType(
   mapSet = { it?.toString() }
 )
 
-fun BundleKeyBuilder.charArray(default: CharArray): BundleKey<CharArray, CharArray?> = charArray().withDefault { default }
+fun BundleKeyBuilder.charArray(default: CharArray): BundleKey<CharArray, CharArray?> = charArray().defaultProvider { default }
 fun BundleKeyBuilder.charArray(): BundleKey<CharArray?, CharArray?> = nativeKey(
   get = { getCharArray(name) },
   set = { setCharArray(name, it) }
 )
 
-fun BundleKeyBuilder.charSequence(default: CharSequence): BundleKey<CharSequence, CharSequence?> = charSequence().withDefault { default }
+fun BundleKeyBuilder.charSequence(default: CharSequence): BundleKey<CharSequence, CharSequence?> = charSequence().defaultProvider { default }
 fun BundleKeyBuilder.charSequence(): BundleKey<CharSequence?, CharSequence?> = nativeKey(
   get = { getCharSequence(name) },
   set = { setCharSequence(name, it) }
 )
 
 fun BundleKeyBuilder.charSequenceArray(default: Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> =
-  charSequenceArray().withDefault { default }
+  charSequenceArray().defaultProvider { default }
 
 fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<CharSequence>?> = nativeKey(
   get = { getCharSequenceArray(name) },
@@ -82,7 +79,7 @@ fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<
 )
 
 fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> =
-  charSequenceList().withDefault { default }
+  charSequenceList().defaultProvider { default }
 
 fun BundleKeyBuilder.charSequenceList(): BundleKey<List<CharSequence>?, ArrayList<CharSequence>?> = charSequenceArrayList().mapType(
   mapGet = { it },

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -3,8 +3,6 @@ package com.episode6.typed2.bundles
 import android.os.Bundle
 import android.os.IBinder
 import com.episode6.typed2.*
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
 
 typealias BundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BundleValueGetter, BundleValueSetter>
 typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BundleValueGetter, BundleValueSetter>
@@ -16,9 +14,11 @@ open class BundleKeyNamespace(private val prefix: String = "") {
 
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)
 
-  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.default(default: ()->T): BundleKey<T, BACKED_BY> = withDefault(default)
-  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.required(): BundleKey<T, BACKED_BY> = asRequired { RequiredBundleKeyMissing(name) }
-  protected fun <T : Any?, BACKED_BY : Any?> BundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncBundleKey<T, BACKED_BY> = asAsync(context)
+  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.default(default: () -> T): BundleKey<T, BACKED_BY> =
+    withDefault(default)
+
+  protected fun <T : Any, BACKED_BY : Any?> BundleKey<T?, BACKED_BY>.required(): BundleKey<T, BACKED_BY> =
+    asRequired { RequiredBundleKeyMissing(name) }
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -73,13 +73,17 @@ fun BundleKeyBuilder.charSequence(): BundleKey<CharSequence?, CharSequence?> = n
   set = { setCharSequence(name, it) }
 )
 
-fun BundleKeyBuilder.charSequenceArray(default: Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> = charSequenceArray().withDefault { default }
+fun BundleKeyBuilder.charSequenceArray(default: Array<CharSequence>): BundleKey<Array<CharSequence>, Array<CharSequence>?> =
+  charSequenceArray().withDefault { default }
+
 fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<CharSequence>?> = nativeKey(
   get = { getCharSequenceArray(name) },
   set = { setCharSequenceArray(name, it) }
 )
 
-fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList().withDefault { default }
+fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> =
+  charSequenceList().withDefault { default }
+
 fun BundleKeyBuilder.charSequenceList(): BundleKey<List<CharSequence>?, ArrayList<CharSequence>?> = charSequenceArrayList().mapType(
   mapGet = { it },
   mapSet = { it?.let { if (it is ArrayList<CharSequence>) it else ArrayList(it) } },

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -6,8 +6,8 @@ import com.episode6.typed2.*
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-typealias BundleKey<T, BACKED_BY> = Key<T, BACKED_BY, in BundleValueGetter, in BundleValueSetter>
-typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in BundleValueGetter, in BundleValueSetter>
+typealias BundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BundleValueGetter, BundleValueSetter>
+typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BundleValueGetter, BundleValueSetter>
 typealias BundleProperty<T> = KeyValueDelegate<T, in BundleValueGetter, in BundleValueSetter>
 
 interface BundleKeyBuilder : BaseBundleKeyBuilder

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -8,13 +8,10 @@ typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, Persi
 typealias PersistableBundleProperty<T> = KeyValueDelegate<T, in PersistableBundleValueGetter, PersistableBundleValueSetter>
 
 interface PersistableBundleKeyBuilder : BaseBundleKeyBuilder
-open class PersistableBundleKeyNamespace(private val prefix: String = "") {
+open class PersistableBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
   private class Builder(override val name: String) : PersistableBundleKeyBuilder
 
   protected fun key(name: String): PersistableBundleKeyBuilder = Builder(prefix + name)
-
-  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.required(): PersistableBundleKey<T, BACKED_BY> =
-    asRequired { RequiredPersistableBundleKeyMissing(name) }
 }
 
 fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> =
@@ -24,5 +21,3 @@ fun PersistableBundleKeyBuilder.persistableBundle(): PersistableBundleKey<Persis
   get = { getPersistableBundle(name) },
   set = { setPersistableBundle(name, it) },
 )
-
-class RequiredPersistableBundleKeyMissing(name: String) : IllegalArgumentException("Required key ($name) missing from persistable bundle")

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -5,9 +5,9 @@ import com.episode6.typed2.*
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-typealias PersistableBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
-typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
-typealias PersistableBundleProperty<T> = KeyValueDelegate<T, in PersistableBundleValueGetter, in PersistableBundleValueSetter>
+typealias PersistableBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, PersistableBundleValueGetter, PersistableBundleValueSetter>
+typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PersistableBundleValueGetter, PersistableBundleValueSetter>
+typealias PersistableBundleProperty<T> = KeyValueDelegate<T, in PersistableBundleValueGetter, PersistableBundleValueSetter>
 
 interface PersistableBundleKeyBuilder : BaseBundleKeyBuilder
 open class PersistableBundleKeyNamespace(private val prefix: String = "") {

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -12,15 +12,13 @@ open class PersistableBundleKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PersistableBundleKeyBuilder
 
   protected fun key(name: String): PersistableBundleKeyBuilder = Builder(prefix + name)
-  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.default(default: () -> T): PersistableBundleKey<T, BACKED_BY> =
-    withDefault(default)
 
   protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.required(): PersistableBundleKey<T, BACKED_BY> =
     asRequired { RequiredPersistableBundleKeyMissing(name) }
 }
 
 fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> =
-  persistableBundle().withDefault { default }
+  persistableBundle().defaultProvider { default }
 
 fun PersistableBundleKeyBuilder.persistableBundle(): PersistableBundleKey<PersistableBundle?, PersistableBundle?> = nativeKey(
   get = { getPersistableBundle(name) },

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -2,8 +2,6 @@ package com.episode6.typed2.bundles
 
 import android.os.PersistableBundle
 import com.episode6.typed2.*
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
 
 typealias PersistableBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, PersistableBundleValueGetter, PersistableBundleValueSetter>
 typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PersistableBundleValueGetter, PersistableBundleValueSetter>
@@ -14,12 +12,16 @@ open class PersistableBundleKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PersistableBundleKeyBuilder
 
   protected fun key(name: String): PersistableBundleKeyBuilder = Builder(prefix + name)
-  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.default(default: ()->T): PersistableBundleKey<T, BACKED_BY> = withDefault(default)
-  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.required(): PersistableBundleKey<T, BACKED_BY> = asRequired { RequiredPersistableBundleKeyMissing(name) }
-  protected fun <T : Any?, BACKED_BY : Any?> PersistableBundleKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncPersistableBundleKey<T, BACKED_BY> = asAsync(context)
+  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.default(default: () -> T): PersistableBundleKey<T, BACKED_BY> =
+    withDefault(default)
+
+  protected fun <T : Any, BACKED_BY : Any?> PersistableBundleKey<T?, BACKED_BY>.required(): PersistableBundleKey<T, BACKED_BY> =
+    asRequired { RequiredPersistableBundleKeyMissing(name) }
 }
 
-fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> = persistableBundle().withDefault { default }
+fun PersistableBundleKeyBuilder.persistableBundle(default: PersistableBundle): PersistableBundleKey<PersistableBundle, PersistableBundle?> =
+  persistableBundle().withDefault { default }
+
 fun PersistableBundleKeyBuilder.persistableBundle(): PersistableBundleKey<PersistableBundle?, PersistableBundle?> = nativeKey(
   get = { getPersistableBundle(name) },
   set = { setPersistableBundle(name, it) },

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -4,8 +4,8 @@ import com.episode6.typed2.*
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, in PrefValueGetter, in PrefValueSetter>
-typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrefValueGetter, in PrefValueSetter>
+typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
+typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
 open class PrefKeyNamespace(private val prefix: String = "") {

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -1,8 +1,6 @@
 package com.episode6.typed2.sharedprefs
 
 import com.episode6.typed2.*
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
 
 typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
 typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
@@ -12,8 +10,7 @@ open class PrefKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PrefKeyBuilder
 
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)
-  protected fun <T : Any, BACKED_BY: Any> PrefKey<T?, BACKED_BY>.default(default: ()->T): PrefKey<T, BACKED_BY> = withDefault(default)
-  protected fun <T : Any?, BACKED_BY : Any?> PrefKey<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncPrefKey<T, BACKED_BY> = asAsync(context)
+  protected fun <T : Any, BACKED_BY : Any> PrefKey<T?, BACKED_BY>.default(default: () -> T): PrefKey<T, BACKED_BY> = withDefault(default)
 }
 
 fun PrefKeyBuilder.double(default: Double): PrefKey<Double, String?> = double().withDefault { default }

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -10,12 +10,11 @@ open class PrefKeyNamespace(private val prefix: String = "") {
   private class Builder(override val name: String) : PrefKeyBuilder
 
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)
-  protected fun <T : Any, BACKED_BY : Any> PrefKey<T?, BACKED_BY>.default(default: () -> T): PrefKey<T, BACKED_BY> = withDefault(default)
 }
 
-fun PrefKeyBuilder.double(default: Double): PrefKey<Double, String?> = double().withDefault { default }
+fun PrefKeyBuilder.double(default: Double): PrefKey<Double, String?> = double().defaultProvider { default }
 
-fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().withDefault { default }
+fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().defaultProvider { default }
 fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }

--- a/core/src/test/kotlin/com/episode6/typed2/BaseBundleTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/BaseBundleTest.kt
@@ -76,7 +76,7 @@ class BaseBundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntNotPresent_pbundle() {
@@ -87,7 +87,7 @@ class BaseBundleTest {
 
     assertThat { persistableBundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntPropertyNotPresent() {
@@ -100,7 +100,7 @@ class BaseBundleTest {
 
     assertThat { result }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntPropertyNotPresent_pbundle() {
@@ -113,7 +113,7 @@ class BaseBundleTest {
 
     assertThat { result }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntIsNull() {
@@ -124,7 +124,7 @@ class BaseBundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntIsNull_pbundle() {
@@ -135,7 +135,7 @@ class BaseBundleTest {
 
     assertThat { persistableBundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBaseBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testSetProperty() {
@@ -224,4 +224,5 @@ class BaseBundleTest {
 }
 
 @Suppress("UNUSED_PARAMETER")
-private fun suppressWarning(thing: ()->Any) {}
+private fun suppressWarning(thing: () -> Any) {
+}

--- a/core/src/test/kotlin/com/episode6/typed2/BundleTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/BundleTest.kt
@@ -52,7 +52,7 @@ class BundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntPropertyNotPresent() {
@@ -65,7 +65,7 @@ class BundleTest {
 
     assertThat { result }
       .isFailure()
-      .hasClass(RequiredBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntIsNull() {
@@ -76,7 +76,7 @@ class BundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
 
@@ -124,4 +124,5 @@ class BundleTest {
 }
 
 @Suppress("UNUSED_PARAMETER")
-private fun suppressWarning(thing: ()->Any) {}
+private fun suppressWarning(thing: () -> Any) {
+}

--- a/core/src/test/kotlin/com/episode6/typed2/PersistableBundleTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/PersistableBundleTest.kt
@@ -53,7 +53,7 @@ class PersistableBundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredPersistableBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntPropertyNotPresent() {
@@ -66,7 +66,7 @@ class PersistableBundleTest {
 
     assertThat { result }
       .isFailure()
-      .hasClass(RequiredPersistableBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntIsNull() {
@@ -77,7 +77,7 @@ class PersistableBundleTest {
 
     assertThat { bundle.get(Keys.myRequiredInt) }
       .isFailure()
-      .hasClass(RequiredPersistableBundleKeyMissing::class)
+      .hasClass(RequiredKeyMissingException::class)
   }
 
 

--- a/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
+++ b/gson/src/main/kotlin/com/episode6/typed2/gson/GsonSerializedKeys.kt
@@ -12,7 +12,7 @@ object Typed2DefaultGson {
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   default: T,
   noinline gson: () -> Gson = Typed2DefaultGson::gson,
-): PrimitiveKey<T, String?> = gson<T>(gson).withDefault { default }
+): PrimitiveKey<T, String?> = gson<T>(gson).defaultProvider { default }
 
 inline fun <reified T : Any> PrimitiveKeyBuilder.gson(
   noinline gson: () -> Gson = Typed2DefaultGson::gson,

--- a/gson/src/test/kotlin/com/episode6/typed2/gson/GsonSerializedKeyTest.kt
+++ b/gson/src/test/kotlin/com/episode6/typed2/gson/GsonSerializedKeyTest.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.*
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.get
 import com.episode6.typed2.bundles.set
 import org.junit.Test
@@ -74,7 +74,7 @@ class JsonSerializedKeyTest {
 
   @Test fun testRequired_get_missing() {
     assertThat { bundle.get(Keys.requiredData) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequired_get_present() {

--- a/kotlinx-serialization-bundlizer/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeys.kt
+++ b/kotlinx-serialization-bundlizer/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeys.kt
@@ -5,7 +5,7 @@ import com.episode6.typed2.bundles.BundleKey
 import com.episode6.typed2.bundles.BundleKeyBuilder
 import com.episode6.typed2.bundles.bundle
 import com.episode6.typed2.mapType
-import com.episode6.typed2.withDefault
+import com.episode6.typed2.defaultProvider
 import dev.ahmedmourad.bundlizer.bundle
 import dev.ahmedmourad.bundlizer.unbundle
 import kotlinx.serialization.KSerializer
@@ -13,7 +13,7 @@ import kotlinx.serialization.KSerializer
 fun <T : Any> BundleKeyBuilder.bundlized(
   default: T,
   serializer: () -> KSerializer<T>,
-): BundleKey<T, Bundle?> = bundlized(serializer).withDefault { default }
+): BundleKey<T, Bundle?> = bundlized(serializer).defaultProvider { default }
 
 fun <T : Any> BundleKeyBuilder.bundlized(
   serializer: () -> KSerializer<T>,

--- a/kotlinx-serialization-bundlizer/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeyTest.kt
+++ b/kotlinx-serialization-bundlizer/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/bundlizer/BundlizedKeyTest.kt
@@ -4,14 +4,13 @@ import android.os.Bundle
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.*
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.get
 import com.episode6.typed2.bundles.set
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
 @kotlinx.serialization.Serializable data class TestData(val name: String)
@@ -81,7 +80,7 @@ class BundlizedKeyTest {
 
   @Test fun testRequired_get_missing() {
     assertThat { bundle.get(Keys.requiredData) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequired_get_present() {

--- a/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
+++ b/kotlinx-serialization-json/src/main/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeys.kt
@@ -8,7 +8,7 @@ fun <T : Any> PrimitiveKeyBuilder.json(
   default: T,
   serializer: () -> KSerializer<T>,
   json: () -> Json = { Json },
-): PrimitiveKey<T, String?> = json(serializer, json).withDefault { default }
+): PrimitiveKey<T, String?> = json(serializer, json).defaultProvider { default }
 
 fun <T : Any> PrimitiveKeyBuilder.json(
   serializer: () -> KSerializer<T>,

--- a/kotlinx-serialization-json/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeyTest.kt
+++ b/kotlinx-serialization-json/src/test/kotlin/com/episode6/typed2/kotlinx/serialization/json/JsonSerializedKeyTest.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.*
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.bundles.get
 import com.episode6.typed2.bundles.set
 import org.junit.Test
@@ -74,7 +74,7 @@ class JsonSerializedKeyTest {
 
   @Test fun testRequired_get_missing() {
     assertThat { bundle.get(Keys.requiredData) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequired_get_present() {

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -7,7 +7,7 @@ typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, PrimitiveKeyValueGetter, Prim
 typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
 
 interface NavArgBuilder : PrimitiveKeyBuilder
-open class NavScreen(val name: String, private val argPrefix: String = "") {
+open class NavScreen(val name: String, private val argPrefix: String = "") : RequiredEnabledKeyNamespace {
 
   private val _args = LinkedHashMap<String, KeyDescriptor<*, *>>()
   internal val args: List<KeyDescriptor<*, *>> get() = _args.values.toList()
@@ -21,8 +21,6 @@ open class NavScreen(val name: String, private val argPrefix: String = "") {
   }
 
   protected fun key(name: String): NavArgBuilder = Builder(argPrefix + name) { _args[it.name] = it }
-  protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.required(): NavArg<T, BACKED_BY> =
-    asRequired { RequiredNavArgumentMissing(name) }
 }
 
 class RequiredNavArgumentMissing(name: String) : RuntimeException("Required nav argument missing: $name")

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -25,7 +25,6 @@ open class NavScreen(val name: String, private val argPrefix: String = "") {
   protected fun key(name: String): NavArgBuilder = Builder(argPrefix + name) { _args[it.name] = it }
   protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.default(default: ()->T): NavArg<T, BACKED_BY> = withDefault(default)
   protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.required(): NavArg<T, BACKED_BY> = asRequired { RequiredNavArgumentMissing(name) }
-  protected fun <T : Any?, BACKED_BY : Any?> NavArg<T, BACKED_BY>.async(context: CoroutineContext = Dispatchers.Default): AsyncNavArg<T, BACKED_BY> = asAsync(context)
 }
 
 class RequiredNavArgumentMissing(name: String) : RuntimeException("Required nav argument missing: $name")

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -5,8 +5,8 @@ import com.episode6.typed2.*
 import kotlinx.coroutines.Dispatchers
 import kotlin.coroutines.CoroutineContext
 
-typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
-typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, in PrimitiveKeyValueGetter, in PrimitiveKeyValueSetter>
+typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
+typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
 
 interface NavArgBuilder : PrimitiveKeyBuilder
 open class NavScreen(val name: String, private val argPrefix: String = "") {

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -2,8 +2,6 @@ package com.episode6.typed2.navigation.compose
 
 import android.net.Uri
 import com.episode6.typed2.*
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.CoroutineContext
 
 typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
 typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
@@ -23,8 +21,8 @@ open class NavScreen(val name: String, private val argPrefix: String = "") {
   }
 
   protected fun key(name: String): NavArgBuilder = Builder(argPrefix + name) { _args[it.name] = it }
-  protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.default(default: ()->T): NavArg<T, BACKED_BY> = withDefault(default)
-  protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.required(): NavArg<T, BACKED_BY> = asRequired { RequiredNavArgumentMissing(name) }
+  protected fun <T : Any, BACKED_BY : Any?> NavArg<T?, BACKED_BY>.required(): NavArg<T, BACKED_BY> =
+    asRequired { RequiredNavArgumentMissing(name) }
 }
 
 class RequiredNavArgumentMissing(name: String) : RuntimeException("Required nav argument missing: $name")

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -22,5 +22,3 @@ open class NavScreen(val name: String, private val argPrefix: String = "") : Req
 
   protected fun key(name: String): NavArgBuilder = Builder(argPrefix + name) { _args[it.name] = it }
 }
-
-class RequiredNavArgumentMissing(name: String) : RuntimeException("Required nav argument missing: $name")

--- a/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/NavScreenArgsTest.kt
+++ b/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/NavScreenArgsTest.kt
@@ -41,6 +41,6 @@ class NavScreenArgsTest {
 
   @Test fun testRequiredInt() {
     assertThat { savedStateHandle.get(TestScreen.requiredInt) }
-      .isFailure().hasClass(RequiredNavArgumentMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 }

--- a/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/test_screens.kt
+++ b/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/test_screens.kt
@@ -1,5 +1,6 @@
 package com.episode6.typed2.navigation.compose
 
+import com.episode6.typed2.async
 import com.episode6.typed2.int
 import com.episode6.typed2.string
 

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -13,9 +13,9 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.int
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -122,7 +122,7 @@ class GetLiveDataTest {
     }
 
     assertThat { savedStateHandle.getLiveData(Keys.requiredInt) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntStateFlow_hasValue() = runTest {
@@ -157,7 +157,7 @@ class GetLiveDataTest {
     }
   }
 
-  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in other coroutine
+  @Test(expected = RequiredKeyMissingException::class) // catches exception in other coroutine
   fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
     val backingLiveData: MutableLiveData<String?> = MutableLiveData(Keys.asyncRequiredInt.backingTypeInfo.default)
     savedStateHandle.stub {

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -13,6 +13,7 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.int

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
@@ -10,6 +10,7 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.int

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
@@ -10,9 +10,9 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.int
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -87,7 +87,7 @@ class GetStateFlowTest {
     }
 
     assertThat { savedStateHandle.stateFlow(Keys.requiredInt, this, SharingStarted.Eagerly) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
   @Test fun testRequiredIntStateFlow_hasValue() = runTest {
@@ -113,7 +113,7 @@ class GetStateFlowTest {
     }
   }
 
-  @Test(expected = RequiredBundleKeyMissing::class) // catches exception in othe coroutine
+  @Test(expected = RequiredKeyMissingException::class) // catches exception in othe coroutine
   fun testRequiredAsyncIntStateFlow_noValue() = runTest(UnconfinedTestDispatcher()) {
     val backingStateFlow: MutableStateFlow<String?> = MutableStateFlow(Keys.asyncRequiredInt.backingTypeInfo.default)
     savedStateHandle.stub {

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleTest.kt
@@ -6,8 +6,8 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
+import com.episode6.typed2.RequiredKeyMissingException
 import com.episode6.typed2.bundles.BundleKeyNamespace
-import com.episode6.typed2.bundles.RequiredBundleKeyMissing
 import com.episode6.typed2.int
 import org.junit.Test
 import org.mockito.kotlin.doAnswer
@@ -60,7 +60,7 @@ class SavedStateHandleTest {
     }
 
     assertThat { savedStateHandle.get(Keys.requiredInt) }
-      .isFailure().hasClass(RequiredBundleKeyMissing::class)
+      .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 }
 


### PR DESCRIPTION
This seems to solve the issue where our KeyTransformation methods don't show up in autocomplete. This lets us define universal  `default`, `required` and `async` methods.