### PR TITLE
Parcelable arrays and lists

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
@@ -31,6 +31,30 @@ object NativeKeys {
     mapper = KeyMapper({ it }, { it }),
     newKeyCallback = keyBuilder.newKeyCallback
   )
+
+  inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> create(
+    keyBuilder: KeyBuilder,
+    backingDefault: T,
+    noinline get: GETTER.() -> T,
+    noinline set: SETTER.(T) -> Unit,
+  ): Key<T, T, GETTER, SETTER> = create(
+    keyBuilder,
+    backingDefault = backingDefault,
+    backingClass = T::class,
+    get = get,
+    set = set,
+  )
+
+  inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> create(
+    keyBuilder: KeyBuilder,
+    noinline get: GETTER.() -> T?,
+    noinline set: SETTER.(T?) -> Unit,
+  ): Key<T?, T?, GETTER, SETTER> = create(
+    keyBuilder,
+    backingClass = T::class,
+    get = get,
+    set = set,
+  )
 }
 
 internal inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBuilder.nativeKey(

--- a/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
@@ -64,7 +64,6 @@ internal inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValue
 ): Key<T, T, GETTER, SETTER> = NativeKeys.create(
   this,
   backingDefault = backingDefault,
-  backingClass = T::class,
   get = get,
   set = set,
 )
@@ -74,7 +73,6 @@ internal inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValue
   noinline set: SETTER.(T?) -> Unit,
 ): Key<T?, T?, GETTER, SETTER> = NativeKeys.create(
   this,
-  backingClass = T::class,
   get = get,
   set = set,
 )

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
@@ -30,6 +30,16 @@ class TypedBundle(private val delegate: Bundle) : BundleValueGetter, BundleValue
     Build.VERSION.SDK_INT >= 33 -> delegate.getParcelable(name, kclass.java)
     else                        -> delegate.getParcelable<T>(name)
   }
+  @Suppress("DEPRECATION")
+  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>? = when {
+    Build.VERSION.SDK_INT >= 33 -> delegate.getParcelableArray(name, kclass.java)
+    else                        -> delegate.getParcelableArray(name)
+  }
+  @Suppress("DEPRECATION")
+  override fun <T : Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>? = when {
+    Build.VERSION.SDK_INT >= 33 -> delegate.getParcelableArrayList(name, kclass.java)
+    else                        -> delegate.getParcelableArrayList<T>(name)
+  }
   override fun getDouble(name: String, default: Double): Double = delegate.getDouble(name, default)
 
   override fun remove(name: String) = delegate.remove(name)
@@ -50,6 +60,8 @@ class TypedBundle(private val delegate: Bundle) : BundleValueGetter, BundleValue
   override fun setFloatArray(name: String, value: FloatArray?) { delegate.putFloatArray(name, value) }
   override fun setIntArrayList(name: String, value: ArrayList<Int>?) { delegate.putIntegerArrayList(name, value) }
   override fun <T : Parcelable> setParcelable(name: String, value: T?) { delegate.putParcelable(name, value) }
+  override fun <T : Parcelable> setParcelableArray(name: String, value: Array<T>?) { delegate.putParcelableArray(name, value) }
+  override fun <T : Parcelable> setParcelableArrayList(name: String, value: ArrayList<T>?) { delegate.putParcelableArrayList(name, value) }
   override fun setDouble(name: String, value: Double) { delegate.putDouble(name, value) }
 }
 

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleExt.kt
@@ -30,10 +30,10 @@ class TypedBundle(private val delegate: Bundle) : BundleValueGetter, BundleValue
     Build.VERSION.SDK_INT >= 33 -> delegate.getParcelable(name, kclass.java)
     else                        -> delegate.getParcelable<T>(name)
   }
-  @Suppress("DEPRECATION")
-  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>? = when {
+  @Suppress("DEPRECATION", "UNCHECKED_CAST")
+  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>, convertListToArray: List<T>.()->Array<T>): Array<T>? = when {
     Build.VERSION.SDK_INT >= 33 -> delegate.getParcelableArray(name, kclass.java)
-    else                        -> delegate.getParcelableArray(name)
+    else                        -> delegate.getParcelableArray(name)?.map { it as T }?.convertListToArray()
   }
   @Suppress("DEPRECATION")
   override fun <T : Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>? = when {

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -77,7 +77,7 @@ fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<
 
 fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList().defaultProvider { default }
 fun BundleKeyBuilder.charSequenceList(): BundleKey<List<CharSequence>?, ArrayList<CharSequence>?> = charSequenceArrayList().mapType(
-  mapGet = { it },
+  mapGet = { it?.toList() },
   mapSet = { it?.let { if (it is ArrayList<CharSequence>) it else ArrayList(it) } },
 )
 
@@ -89,17 +89,29 @@ fun BundleKeyBuilder.floatArray(): BundleKey<FloatArray?, FloatArray?> = nativeK
 
 fun BundleKeyBuilder.intList(default: List<Int>): BundleKey<List<Int>, ArrayList<Int>?> = intList().defaultProvider { default }
 fun BundleKeyBuilder.intList(): BundleKey<List<Int>?, ArrayList<Int>?> = intArrayList().mapType(
-  mapGet = { it },
+  mapGet = { it?.toList() },
   mapSet = { it?.let { if (it is ArrayList<Int>) it else ArrayList(it) } },
 )
 
 inline fun <reified T : Parcelable> BundleKeyBuilder.parcelable(default: T) : BundleKey<T, T?> = parcelable<T>().defaultProvider { default }
-inline fun <reified T : Parcelable> BundleKeyBuilder.parcelable() : BundleKey<T?, T?> = parcelable(T::class)
-fun <T : Parcelable> BundleKeyBuilder.parcelable(kclass: KClass<T>) : BundleKey<T?, T?> = NativeKeys.create(
+inline fun <reified T : Parcelable> BundleKeyBuilder.parcelable() : BundleKey<T?, T?> = NativeKeys.create(
   this,
-  backingClass = kclass,
-  get = { getParcelable(name, kclass) },
+  get = { getParcelable(name, T::class) },
   set = { setParcelable(name, it) },
+)
+
+inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableArray(default: Array<T>): BundleKey<Array<T>, Array<T>?> = parcelableArray<T>().defaultProvider { default }
+inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableArray(): BundleKey<Array<T>?, Array<T>?> = NativeKeys.create(
+  this,
+  get = { getParcelableArray(name, T::class, convertListToArray = { toTypedArray() }) },
+  set = { setParcelableArray(name, it) },
+)
+
+inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableList(default: List<T>): BundleKey<List<T>, ArrayList<T>?> = parcelableList<T>().defaultProvider { default }
+inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableList(): BundleKey<List<T>?, ArrayList<T>?> = parcelableList(T::class)
+fun <T : Parcelable> BundleKeyBuilder.parcelableList(kclass: KClass<T>): BundleKey<List<T>?, ArrayList<T>?> = parcelableArrayList(kclass).mapType(
+  mapGet = { it?.toList() },
+  mapSet = { it?.let { if (it is ArrayList<T>) it else ArrayList<T>(it) } }
 )
 
 private fun BundleKeyBuilder.nativeBinder(): BundleKey<IBinder?, IBinder?> = nativeKey(
@@ -115,4 +127,10 @@ private fun BundleKeyBuilder.charSequenceArrayList(): BundleKey<ArrayList<CharSe
 private fun BundleKeyBuilder.intArrayList(): BundleKey<ArrayList<Int>?, ArrayList<Int>?> = nativeKey(
   get = { getIntArrayList(name) },
   set = { setIntArrayList(name, it) }
+)
+
+private fun <T : Parcelable> BundleKeyBuilder.parcelableArrayList(kclass: KClass<T>): BundleKey<ArrayList<T>?, ArrayList<T>?> = NativeKeys.create(
+  this,
+  get = { getParcelableArrayList(name, kclass) },
+  set = { setParcelableArrayList(name, it) },
 )

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -77,7 +77,7 @@ fun BundleKeyBuilder.charSequenceArray(): BundleKey<Array<CharSequence>?, Array<
 
 fun BundleKeyBuilder.charSequenceList(default: List<CharSequence>): BundleKey<List<CharSequence>, ArrayList<CharSequence>?> = charSequenceList().defaultProvider { default }
 fun BundleKeyBuilder.charSequenceList(): BundleKey<List<CharSequence>?, ArrayList<CharSequence>?> = charSequenceArrayList().mapType(
-  mapGet = { it?.toList() },
+  mapGet = { it },
   mapSet = { it?.let { if (it is ArrayList<CharSequence>) it else ArrayList(it) } },
 )
 
@@ -89,7 +89,7 @@ fun BundleKeyBuilder.floatArray(): BundleKey<FloatArray?, FloatArray?> = nativeK
 
 fun BundleKeyBuilder.intList(default: List<Int>): BundleKey<List<Int>, ArrayList<Int>?> = intList().defaultProvider { default }
 fun BundleKeyBuilder.intList(): BundleKey<List<Int>?, ArrayList<Int>?> = intArrayList().mapType(
-  mapGet = { it?.toList() },
+  mapGet = { it },
   mapSet = { it?.let { if (it is ArrayList<Int>) it else ArrayList(it) } },
 )
 
@@ -110,7 +110,7 @@ inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableArray(): BundleKe
 inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableList(default: List<T>): BundleKey<List<T>, ArrayList<T>?> = parcelableList<T>().defaultProvider { default }
 inline fun <reified T : Parcelable> BundleKeyBuilder.parcelableList(): BundleKey<List<T>?, ArrayList<T>?> = parcelableList(T::class)
 fun <T : Parcelable> BundleKeyBuilder.parcelableList(kclass: KClass<T>): BundleKey<List<T>?, ArrayList<T>?> = parcelableArrayList(kclass).mapType(
-  mapGet = { it?.toList() },
+  mapGet = { it },
   mapSet = { it?.let { if (it is ArrayList<T>) it else ArrayList<T>(it) } }
 )
 

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
@@ -20,6 +20,8 @@ interface BundleValueGetter : BaseBundleValueGetter {
   fun getFloatArray(name: String): FloatArray?
   fun getIntArrayList(name: String): ArrayList<Int>?
   fun <T: Parcelable> getParcelable(name: String, kclass: KClass<T>): T?
+  fun <T: Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>?
+  fun <T: Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>?
 }
 
 interface BundleValueSetter : BaseBundleValueSetter {
@@ -35,6 +37,8 @@ interface BundleValueSetter : BaseBundleValueSetter {
   fun setFloatArray(name: String, value: FloatArray?)
   fun setIntArrayList(name: String, value: ArrayList<Int>?)
   fun <T: Parcelable> setParcelable(name: String, value: T?)
+  fun <T: Parcelable> setParcelableArray(name: String, value: Array<T>?)
+  fun <T: Parcelable> setParcelableArrayList(name: String, value: ArrayList<T>?)
 }
 
 fun <T> BundleValueGetter.get(key: BundleKey<T, *>): T = key.get(this)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundlesKeyValueStore.kt
@@ -20,7 +20,7 @@ interface BundleValueGetter : BaseBundleValueGetter {
   fun getFloatArray(name: String): FloatArray?
   fun getIntArrayList(name: String): ArrayList<Int>?
   fun <T: Parcelable> getParcelable(name: String, kclass: KClass<T>): T?
-  fun <T: Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>?
+  fun <T: Parcelable> getParcelableArray(name: String, kclass: KClass<T>, convertListToArray: List<T>.()->Array<T>): Array<T>?
   fun <T: Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>?
 }
 

--- a/core/src/test/kotlin/com/episode6/typed2/BundleKeysTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/BundleKeysTest.kt
@@ -38,6 +38,7 @@ class BundleKeysTest {
     on { getChar(any(), any()) } doAnswer { it.getArgument(1) }
     on { getCharSequenceArrayList(any()) } doReturn null
     on { getIntArrayList(any()) } doReturn null
+    on { getParcelableArrayList<TestParcelable>(any(), any()) } doReturn null
     on { getString(any(), anyOrNull()) } doAnswer { it.getArgument(1) }
   }
 

--- a/core/src/test/kotlin/com/episode6/typed2/BundleKeysTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/BundleKeysTest.kt
@@ -28,6 +28,8 @@ class BundleKeysTest {
     val floatArray = key("floatArray").floatArray()
     val intList = key("intList").intList()
     val parcelable = key("parcelable").parcelable<TestParcelable>()
+    val parcelableArray = key("parcelableArray").parcelableArray<TestParcelable>()
+    val parcelableList = key("parcelableList").parcelableList<TestParcelable>()
   }
 
   private val getter: BundleValueGetter = mock {
@@ -184,6 +186,32 @@ class BundleKeysTest {
     inOrder(getter, setter) {
       verify(getter).getParcelable("parcelable", TestParcelable::class)
       verify(setter).setParcelable("parcelable", mockParcelable)
+    }
+  }
+
+  @Test fun testParcelableArray() {
+    val mockParcelable = mock<TestParcelable>()
+    val array: Array<TestParcelable> = arrayOf(mockParcelable)
+
+    assertThat(getter.get(Keys.parcelableArray)).isNull()
+    setter.set(Keys.parcelableArray, array)
+
+    inOrder(getter, setter) {
+      verify(getter).getParcelableArray(eq("parcelableArray"), eq(TestParcelable::class), any())
+      verify(setter).setParcelableArray("parcelableArray", array)
+    }
+  }
+
+  @Test fun testParcelableList() {
+    val mockParcelable = mock<TestParcelable>()
+    val list: List<TestParcelable> = listOf(mockParcelable)
+
+    assertThat(getter.get(Keys.parcelableList)).isNull()
+    setter.set(Keys.parcelableList, list)
+
+    inOrder(getter, setter) {
+      verify(getter).getParcelableArrayList(eq("parcelableList"), eq(TestParcelable::class))
+      verify(setter).setParcelableArrayList("parcelableList", ArrayList(list))
     }
   }
 }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -22,7 +22,9 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun getFloatArray(name: String): FloatArray? = delegate[name]
   override fun getIntArrayList(name: String): ArrayList<Int>? = delegate[name]
   override fun <T : Parcelable> getParcelable(name: String, kclass: KClass<T>): T? = delegate[name]
-  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>? = delegate[name]
+  @Suppress("UNCHECKED_CAST")
+  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>, convertListToArray: List<T>.()->Array<T>): Array<T>? =
+    delegate.get<Array<Parcelable>>(name)?.map { it as T }?.convertListToArray()
   override fun <T : Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>? = delegate[name]
   override fun getDouble(name: String, default: Double): Double = delegate[name] ?: default
   override fun getBoolean(name: String, default: Boolean): Boolean = delegate[name] ?: default
@@ -43,7 +45,7 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun setFloatArray(name: String, value: FloatArray?) { delegate[name] = value }
   override fun setIntArrayList(name: String, value: ArrayList<Int>?) { delegate[name] = value }
   override fun <T : Parcelable> setParcelable(name: String, value: T?) { delegate[name] = value }
-  override fun <T : Parcelable> setParcelableArray(name: String, value: Array<T>?) { delegate[name] = value }
+  override fun <T : Parcelable> setParcelableArray(name: String, value: Array<T>?) { delegate[name] = value?.map { it as Parcelable }?.toTypedArray<Parcelable>() }
   override fun <T : Parcelable> setParcelableArrayList(name: String, value: ArrayList<T>?) { delegate[name] = value }
   override fun setDouble(name: String, value: Double) { delegate[name] = value }
   override fun setInt(name: String, value: Int) { delegate[name] = value }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/SavedStateHandleExt.kt
@@ -22,6 +22,8 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun getFloatArray(name: String): FloatArray? = delegate[name]
   override fun getIntArrayList(name: String): ArrayList<Int>? = delegate[name]
   override fun <T : Parcelable> getParcelable(name: String, kclass: KClass<T>): T? = delegate[name]
+  override fun <T : Parcelable> getParcelableArray(name: String, kclass: KClass<T>): Array<in T>? = delegate[name]
+  override fun <T : Parcelable> getParcelableArrayList(name: String, kclass: KClass<T>): ArrayList<T>? = delegate[name]
   override fun getDouble(name: String, default: Double): Double = delegate[name] ?: default
   override fun getBoolean(name: String, default: Boolean): Boolean = delegate[name] ?: default
   override fun getFloat(name: String, default: Float): Float = delegate[name] ?: default
@@ -41,6 +43,8 @@ class TypedSavedStateHandle(private val delegate: SavedStateHandle) : BundleValu
   override fun setFloatArray(name: String, value: FloatArray?) { delegate[name] = value }
   override fun setIntArrayList(name: String, value: ArrayList<Int>?) { delegate[name] = value }
   override fun <T : Parcelable> setParcelable(name: String, value: T?) { delegate[name] = value }
+  override fun <T : Parcelable> setParcelableArray(name: String, value: Array<T>?) { delegate[name] = value }
+  override fun <T : Parcelable> setParcelableArrayList(name: String, value: ArrayList<T>?) { delegate[name] = value }
   override fun setDouble(name: String, value: Double) { delegate[name] = value }
   override fun setInt(name: String, value: Int) { delegate[name] = value }
   override fun setString(name: String, value: String?) { delegate[name] = value }


### PR DESCRIPTION
piggyback, add public inline NativeKeys.create methods with a reified T and no need for a KClass