### PR TITLE
Remove get/set extensions on primitive getter/setter

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/PrimitiveKeyValueStore.kt
@@ -15,10 +15,3 @@ interface PrimitiveKeyValueSetter : KeyValueSetter {
   fun setLong(name: String, value: Long)
   fun setString(name: String, value: String?)
 }
-
-fun <T> PrimitiveKeyValueGetter.get(key: PrimitiveKey<T, *>): T = key.get(this)
-fun <T> PrimitiveKeyValueSetter.set(key: PrimitiveKey<T, *>, value: T) = key.set(this, value)
-fun PrimitiveKeyValueSetter.remove(key: PrimitiveKey<*, *>) = remove(key.name)
-suspend fun <T> PrimitiveKeyValueGetter.get(key: AsyncPrimitiveKey<T, *>): T = key.get(this)
-suspend fun <T> PrimitiveKeyValueSetter.set(key: AsyncPrimitiveKey<T, *>, value: T) = key.set(this, value)
-fun PrimitiveKeyValueSetter.remove(key: AsyncPrimitiveKey<*, *>) = remove(key.name)

--- a/core/src/test/kotlin/com/episode6/typed2/PrimitiveKeysTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/PrimitiveKeysTest.kt
@@ -38,6 +38,9 @@ class PrimitiveKeysTest {
 
   private val setter: PrimitiveKeyValueSetter = mock()
 
+  private fun <T> PrimitiveKeyValueGetter.get(key: PrimitiveKey<T, *>): T = key.get(this)
+  private fun <T> PrimitiveKeyValueSetter.set(key: PrimitiveKey<T, *>, value: T) = key.set(this, value)
+
   @Test fun testBool() {
     assertThat(getter.get(Keys.bool)).isTrue()
     setter.set(Keys.bool, false)


### PR DESCRIPTION
Life gets a little easier if we only add get/set extension methods on top-level getter/setter types