### PR TITLE
Make PrefKey only take one arg

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeyValueStore.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeyValueStore.kt
@@ -10,11 +10,11 @@ interface PrefValueSetter : PrimitiveKeyValueSetter {
   fun setStringSet(name: String, value: Set<String?>?)
 }
 
-fun <T> PrefValueGetter.get(key: PrefKey<T, *>): T = key.get(this)
-fun <T> PrefValueSetter.set(key: PrefKey<T, *>, value: T) = key.set(this, value)
-fun PrefValueSetter.remove(key: PrefKey<*, *>) = remove(key.name)
-suspend fun <T> PrefValueGetter.get(key: AsyncPrefKey<T, *>): T = key.get(this)
-suspend fun <T> PrefValueSetter.set(key: AsyncPrefKey<T, *>, value: T) = key.set(this, value)
-fun PrefValueSetter.remove(key: AsyncPrefKey<*, *>) = remove(key.name)
+fun <T> PrefValueGetter.get(key: PrefKey<T>): T = key.get(this)
+fun <T> PrefValueSetter.set(key: PrefKey<T>, value: T) = key.set(this, value)
+fun PrefValueSetter.remove(key: PrefKey<*>) = remove(key.name)
+suspend fun <T> PrefValueGetter.get(key: AsyncPrefKey<T>): T = key.get(this)
+suspend fun <T> PrefValueSetter.set(key: AsyncPrefKey<T>, value: T) = key.set(this, value)
+fun PrefValueSetter.remove(key: AsyncPrefKey<*>) = remove(key.name)
 
 

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -2,8 +2,9 @@ package com.episode6.typed2.sharedprefs
 
 import com.episode6.typed2.*
 
-typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
-typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
+typealias FullPrefKey<T, BACKED_BY> = Key<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
+typealias PrefKey<T> = FullPrefKey<T, *>
+typealias AsyncPrefKey<T> = AsyncKey<T, *, PrefValueGetter, PrefValueSetter>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
 open class PrefKeyNamespace(private val prefix: String = "") {
@@ -12,15 +13,15 @@ open class PrefKeyNamespace(private val prefix: String = "") {
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)
 }
 
-fun PrefKeyBuilder.double(default: Double): PrefKey<Double, String?> = double().defaultProvider { default }
+fun PrefKeyBuilder.double(default: Double): FullPrefKey<Double, String?> = double().defaultProvider { default }
 
-fun PrefKeyBuilder.stringSet(default: Set<String>): PrefKey<Set<String>, Set<String?>?> = stringSet().defaultProvider { default }
-fun PrefKeyBuilder.stringSet(): PrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
+fun PrefKeyBuilder.stringSet(default: Set<String>): FullPrefKey<Set<String>, Set<String?>?> = stringSet().defaultProvider { default }
+fun PrefKeyBuilder.stringSet(): FullPrefKey<Set<String>?, Set<String?>?> = nullableStringSet().mapType(
   mapGet = { it?.filterNotNull()?.toSet() },
   mapSet = { it }
 )
 
-fun PrefKeyBuilder.nullableStringSet(): PrefKey<Set<String?>?, Set<String?>?> = nativeKey(
+fun PrefKeyBuilder.nullableStringSet(): FullPrefKey<Set<String?>?, Set<String?>?> = nativeKey(
   get = { getStringSet(name, null) },
   set = { setStringSet(name, it) },
 )

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
@@ -32,12 +32,12 @@ class TypedSharedPreferences(private val delegate: SharedPreferences) : PrefValu
 fun SharedPreferences.typed(): TypedSharedPreferences = TypedSharedPreferences(this)
 fun SharedPreferences.Editor.typed(): TypedSharedPreferences.Editor = TypedSharedPreferences.Editor(this)
 
-fun <T> SharedPreferences.get(key: PrefKey<T, *>): T = typed().get(key)
-fun <T> SharedPreferences.Editor.set(key: PrefKey<T, *>, value: T) = typed().set(key, value)
-fun SharedPreferences.Editor.remove(key: PrefKey<*, *>) = typed().remove(key)
-suspend fun <T> SharedPreferences.get(key: AsyncPrefKey<T, *>): T = typed().get(key)
-suspend fun <T> SharedPreferences.Editor.set(key: AsyncPrefKey<T, *>, value: T) = typed().set(key, value)
-fun SharedPreferences.Editor.remove(key: AsyncPrefKey<*, *>) = typed().remove(key)
+fun <T> SharedPreferences.get(key: PrefKey<T>): T = typed().get(key)
+fun <T> SharedPreferences.Editor.set(key: PrefKey<T>, value: T) = typed().set(key, value)
+fun SharedPreferences.Editor.remove(key: PrefKey<*>) = typed().remove(key)
+suspend fun <T> SharedPreferences.get(key: AsyncPrefKey<T>): T = typed().get(key)
+suspend fun <T> SharedPreferences.Editor.set(key: AsyncPrefKey<T>, value: T) = typed().set(key, value)
+fun SharedPreferences.Editor.remove(key: AsyncPrefKey<*>) = typed().remove(key)
 
 inline fun SharedPreferences.edit(
   commit: Boolean = false,

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesFlows.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesFlows.kt
@@ -8,24 +8,25 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
 
-fun <T> SharedPreferences.flow(key: PrefKey<T, *>): Flow<T> =
+fun <T> SharedPreferences.flow(key: PrefKey<T>): Flow<T> =
   changedKeyNames()
     .filter { it == key.name }
     .mapLatest { get(key) }
+    .onStart { emit(get(key)) }
     .distinctUntilChanged()
 
-fun <T> SharedPreferences.flow(key: AsyncPrefKey<T, *>): Flow<T> =
+fun <T> SharedPreferences.flow(key: AsyncPrefKey<T>): Flow<T> =
   changedKeyNames()
     .filter { it == key.name }
     .mapLatest { get(key) }
+    .onStart { emit(get(key)) }
     .distinctUntilChanged()
 
-fun <T> SharedPreferences.stateFlow(key: PrefKey<T, *>, scope: CoroutineScope, started: SharingStarted): StateFlow<T> =
+fun <T> SharedPreferences.stateFlow(key: PrefKey<T>, scope: CoroutineScope, started: SharingStarted): StateFlow<T> =
   flow(key).stateIn(scope, started, get(key))
 
-fun <T> SharedPreferences.sharedFlow(key: AsyncPrefKey<T, *>, scope: CoroutineScope, started: SharingStarted, replay: Int = 1): SharedFlow<T> =
+fun <T> SharedPreferences.sharedFlow(key: AsyncPrefKey<T>, scope: CoroutineScope, started: SharingStarted, replay: Int = 1): SharedFlow<T> =
   flow(key)
-    .onStart { emit(get(key)) }
     .conflate()
     .shareIn(scope, started, replay)
 

--- a/core/src/test/kotlin/com/episode6/typed2/GetSharedPrefFlowTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/GetSharedPrefFlowTest.kt
@@ -7,9 +7,7 @@ import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import com.episode6.typed2.sharedprefs.PrefKeyNamespace
-import com.episode6.typed2.sharedprefs.sharedFlow
-import com.episode6.typed2.sharedprefs.stateFlow
+import com.episode6.typed2.sharedprefs.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -22,9 +20,9 @@ import org.mockito.kotlin.*
 class GetSharedPrefFlowTest {
 
   object Keys : PrefKeyNamespace() {
-    val intKey = key("intKey").int(default = 2)
-    val nullableIntKey = key("nullableInt").int()
-    val asyncKey = key("asyncInt").int().async()
+    val intKey: PrefKey<Int> = key("intKey").int(default = 2)
+    val nullableIntKey: PrefKey<Int?> = key("nullableInt").int()
+    val asyncKey: AsyncPrefKey<Int?> = key("asyncInt").int().async()
   }
 
   private val listener = MutableSharedFlow<SharedPreferences.OnSharedPreferenceChangeListener>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)

--- a/core/src/test/kotlin/com/episode6/typed2/SharedPrefTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/SharedPrefTest.kt
@@ -15,11 +15,11 @@ import org.mockito.kotlin.*
 class SharedPrefTest {
 
   object Keys : PrefKeyNamespace("com.prefix.") {
-    val myInt = key("intKey").int(default = 42)
-    val myNullInt = key("nullableInt").int()
-    val myStringSet = key("stringSet").stringSet()
-    val myAsyncString = key("asyncString").string().async()
-    val myDouble = key("double").double()
+    val myInt: PrefKey<Int> = key("intKey").int(default = 42)
+    val myNullInt: PrefKey<Int?> = key("nullableInt").int()
+    val myStringSet: PrefKey<Set<String>?> = key("stringSet").stringSet()
+    val myAsyncString: AsyncPrefKey<String?> = key("asyncString").string().async()
+    val myDouble: PrefKey<Double?> = key("double").double()
   }
 
   val editor: SharedPreferences.Editor = mock()


### PR DESCRIPTION
When we create/return new pref keys we always use FullPrefKey for complete precision, however end users usually won't care what the keys are backed by and it only adds to verbosity if the user want's to expose the types intentionally.