### PR TITLE
remove our custom SharedPref.edit extension since it shadows core ktx

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
   implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.androidx.core.ktx)
   testImplementation(libs.bundles.test.support)
   testImplementation(libs.turbine.core)
 }

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/SharedPreferencesExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.typed2.sharedprefs
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -24,6 +25,7 @@ class TypedSharedPreferences(private val delegate: SharedPreferences) : PrefValu
     override fun setFloat(name: String, value: Float) { delegate.putFloat(name, value) }
     override fun setLong(name: String, value: Long) { delegate.putLong(name, value) }
     override fun setStringSet(name: String, value: Set<String?>?) { delegate.putStringSet(name, value) }
+    fun clear() { delegate.clear() }
     fun commit() { delegate.commit() }
     fun apply() { delegate.apply() }
   }
@@ -39,11 +41,6 @@ suspend fun <T> SharedPreferences.get(key: AsyncPrefKey<T, *>): T = typed().get(
 suspend fun <T> SharedPreferences.Editor.set(key: AsyncPrefKey<T, *>, value: T) = typed().set(key, value)
 fun SharedPreferences.Editor.remove(key: AsyncPrefKey<*, *>) = typed().remove(key)
 
-inline fun SharedPreferences.edit(
-  commit: Boolean = false,
-  action: TypedSharedPreferences.Editor.() -> Unit,
-) = typed().edit(commit = commit, action = action)
-
 inline fun TypedSharedPreferences.edit(
   commit: Boolean = false,
   action: TypedSharedPreferences.Editor.() -> Unit,
@@ -57,8 +54,8 @@ inline fun TypedSharedPreferences.edit(
 fun SharedPreferences.launchEdit(
   scope: CoroutineScope,
   commit: Boolean = false,
-  action: suspend TypedSharedPreferences.Editor.() -> Unit,
-): Job = typed().launchEdit(scope = scope, commit = commit, action = action)
+  action: suspend SharedPreferences.Editor.() -> Unit,
+): Job = scope.launch { edit(commit = commit) { action() } }
 
 fun TypedSharedPreferences.launchEdit(
   scope: CoroutineScope,

--- a/core/src/test/kotlin/com/episode6/typed2/SharedPrefTest.kt
+++ b/core/src/test/kotlin/com/episode6/typed2/SharedPrefTest.kt
@@ -3,6 +3,7 @@
 package com.episode6.typed2
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull


### PR DESCRIPTION
also updates our SharedPrefs.launchEdit to take a `suspend SharedPreferences.Editor.() -> Unit` lambda