### PR TITLE
Add some SavedStateHandle Flow and LiveData instrumentation tests & fix impl

### DIFF
--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -53,5 +53,6 @@ dependencies {
   androidTestImplementation(libs.assertk.core)
   androidTestImplementation(libs.turbine.core)
   androidTestImplementation(libs.kotlinx.coroutines.test)
-
+  androidTestImplementation(libs.androidx.livedata)
+  androidTestImplementation(libs.androidx.testing.arch.core)
 }

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
@@ -1,0 +1,111 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.episode6.typed2.sampleapp
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asFlow
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.episode6.typed2.*
+import com.episode6.typed2.bundles.*
+import com.episode6.typed2.savedstatehandle.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+class SavedStateHandleFlowLiveDataInstrumentedTest {
+
+  private object Keys : BundleKeyNamespace() {
+    val string = key("string").string(default = "default")
+    val asyncString = key("asyncString").string(default = "default").async(UnconfinedTestDispatcher())
+  }
+
+  private val dispatcher = StandardTestDispatcher()
+
+  @get:Rule val instantExecutor = InstantTaskExecutorRule()
+
+  @Before
+  fun setup() {
+    Dispatchers.setMain(dispatcher)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  private val handle = SavedStateHandle()
+
+  @Test fun testStateFlow() = runTest {
+    launch {
+      val stateFlow = handle.getStateFlow(Keys.string, this, SharingStarted.WhileSubscribed())
+
+      assertThat(stateFlow.value).isEqualTo("default")
+
+      stateFlow.test(timeout = 10.seconds) {
+        assertThat(awaitItem()).isEqualTo("default")
+
+        handle.set(Keys.string, "newValue")
+
+        assertThat(awaitItem()).isEqualTo("newValue")
+      }
+      cancel()
+    }
+  }
+
+  @Test fun testSharedFlow() = runTest {
+    launch {
+      handle.getSharedFlow(Keys.asyncString, this, SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
+        assertThat(awaitItem()).isEqualTo("default")
+
+        handle.set(Keys.asyncString, "newValue")
+
+        assertThat(awaitItem()).isEqualTo("newValue")
+      }
+      cancel()
+    }
+  }
+
+  @Test fun testLiveData() = runTest {
+    launch {
+      val liveData = handle.getLiveData(Keys.string)
+
+      assertThat(liveData.value).isEqualTo("default")
+
+      liveData.asFlow().test(timeout = 10.seconds) {
+        assertThat(awaitItem()).isEqualTo("default")
+
+        liveData.value = "newValue"
+
+        assertThat(awaitItem()).isEqualTo("newValue")
+
+        assertThat(handle.get(Keys.string)).isEqualTo("newValue")
+      }
+      cancel()
+    }
+  }
+
+  @Test fun testAsyncLiveData() = runTest {
+    launch {
+      val liveData = handle.getLiveData(Keys.asyncString, this)
+
+      liveData.asFlow().test(timeout = 10.seconds) {
+        assertThat(awaitItem()).isEqualTo("default")
+
+        liveData.value = "newValue"
+
+        assertThat(awaitItem()).isEqualTo("newValue")
+
+        assertThat(handle.get(Keys.asyncString)).isEqualTo("newValue")
+      }
+      cancel()
+    }
+  }
+}

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
@@ -85,7 +85,9 @@ class SavedStateHandleFlowLiveDataInstrumentedTest {
       liveData.asFlow().test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")
 
-        liveData.value = "newValue"
+        withContext(UnconfinedTestDispatcher()) {
+          liveData.value = "newValue"
+        }
 
         assertThat(awaitItem()).isEqualTo("newValue")
 

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
@@ -14,8 +14,6 @@ import com.episode6.typed2.savedstatehandle.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.test.*
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import kotlin.time.Duration.Companion.seconds
@@ -27,19 +25,7 @@ class SavedStateHandleFlowLiveDataInstrumentedTest {
     val asyncString = key("asyncString").string(default = "default").async(UnconfinedTestDispatcher())
   }
 
-  private val dispatcher = StandardTestDispatcher()
-
   @get:Rule val instantExecutor = InstantTaskExecutorRule()
-
-  @Before
-  fun setup() {
-    Dispatchers.setMain(dispatcher)
-  }
-
-  @After
-  fun tearDown() {
-    Dispatchers.resetMain()
-  }
 
   private val handle = SavedStateHandle()
 

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SavedStateHandleFlowLiveDataInstrumentedTest.kt
@@ -31,7 +31,7 @@ class SavedStateHandleFlowLiveDataInstrumentedTest {
 
   @Test fun testStateFlow() = runTest {
     launch {
-      val stateFlow = handle.getStateFlow(Keys.string, this, SharingStarted.WhileSubscribed())
+      val stateFlow = handle.getStateFlow(Keys.string, this + UnconfinedTestDispatcher(), SharingStarted.WhileSubscribed())
 
       assertThat(stateFlow.value).isEqualTo("default")
 
@@ -48,7 +48,7 @@ class SavedStateHandleFlowLiveDataInstrumentedTest {
 
   @Test fun testSharedFlow() = runTest {
     launch {
-      handle.getSharedFlow(Keys.asyncString, this, SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
+      handle.getSharedFlow(Keys.asyncString, this + UnconfinedTestDispatcher(), SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")
 
         handle.set(Keys.asyncString, "newValue")
@@ -80,7 +80,7 @@ class SavedStateHandleFlowLiveDataInstrumentedTest {
 
   @Test fun testAsyncLiveData() = runTest {
     launch {
-      val liveData = handle.getLiveData(Keys.asyncString, this)
+      val liveData = handle.getLiveData(Keys.asyncString, this + UnconfinedTestDispatcher())
 
       liveData.asFlow().test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
@@ -207,7 +207,7 @@ class SharedPrefInstrumentedTest {
       sharedPrefs.sharedFlow(Keys.asyncString, this, SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")
 
-        sharedPrefs.edit { set(Keys.asyncString, "newValue") }
+        sharedPrefs.edit(true) { set(Keys.asyncString, "newValue") }
 
         assertThat(awaitItem()).isEqualTo("newValue")
       }

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -37,7 +38,7 @@ class SharedPrefInstrumentedTest {
 
     val string = key("string").string(default = "default")
     val nullString = key("nullString").string()
-    val asyncString = key("asyncString").string(default = "default").async()
+    val asyncString = key("asyncString").string(default = "default").async(UnconfinedTestDispatcher())
   }
 
   private val sharedPrefs: SharedPreferences by lazy {
@@ -206,7 +207,7 @@ class SharedPrefInstrumentedTest {
       sharedPrefs.sharedFlow(Keys.asyncString, this, SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")
 
-        sharedPrefs.edit(true) { set(Keys.asyncString, "newValue") }
+        sharedPrefs.edit { set(Keys.asyncString, "newValue") }
 
         assertThat(awaitItem()).isEqualTo("newValue")
       }

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/SharedPrefInstrumentedTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -187,7 +188,7 @@ class SharedPrefInstrumentedTest {
 
   @Test fun testStateFlow() = runTest {
     launch {
-      val stateFlow = sharedPrefs.stateFlow(Keys.string, this, SharingStarted.WhileSubscribed())
+      val stateFlow = sharedPrefs.stateFlow(Keys.string, this + UnconfinedTestDispatcher(), SharingStarted.WhileSubscribed())
 
       assertThat(stateFlow.value).isEqualTo("default")
 
@@ -204,7 +205,7 @@ class SharedPrefInstrumentedTest {
 
   @Test fun testAsyncSharedFlow() = runTest {
     launch {
-      sharedPrefs.sharedFlow(Keys.asyncString, this, SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
+      sharedPrefs.sharedFlow(Keys.asyncString, this + UnconfinedTestDispatcher(), SharingStarted.WhileSubscribed()).test(timeout = 10.seconds) {
         assertThat(awaitItem()).isEqualTo("default")
 
         sharedPrefs.edit(true) { set(Keys.asyncString, "newValue") }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
@@ -1,6 +1,9 @@
 package com.episode6.typed2.savedstatehandle
 
-import androidx.lifecycle.*
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asFlow
 import com.episode6.typed2.AsyncKey
 import com.episode6.typed2.Key
 import com.episode6.typed2.provider
@@ -15,7 +18,7 @@ fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, BACKED_BY, *, *>): M
   val backingLiveData = getLiveData(key.name, key.backingTypeInfo.default)
   val result = MutableMediatorLiveData<T>(onNewValue = { backingLiveData.value = key.mapper.mapSet(it) })
   backingLiveData.value?.let { result.setValueSkipCallback(key.mapper.mapGet(it)) } ?: key.outputDefault?.provider()?.invoke()?.let {  result.setValueSkipCallback(it) }
-  result.addSource(backingLiveData.distinctUntilChanged()) { result.setValueSkipCallback(key.mapper.mapGet(it)) }
+  result.addSource(backingLiveData) { result.setValueSkipCallback(key.mapper.mapGet(it)) }
   return result
 }
 

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetLiveData.kt
@@ -23,8 +23,8 @@ fun <T, BACKED_BY> SavedStateHandle.getLiveData(key: Key<T, BACKED_BY, *, *>): M
 }
 
 fun <T, BACKED_BY> SavedStateHandle.getLiveData(
-  scope: CoroutineScope,
   key: AsyncKey<T, BACKED_BY, *, *>,
+  scope: CoroutineScope,
 ): MutableLiveData<T> {
   val newValues = MutableSharedFlow<T>(replay = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
   val backingLiveData = getLiveData(key.name, key.backingTypeInfo.default)
@@ -40,11 +40,13 @@ fun <T, BACKED_BY> SavedStateHandle.getLiveData(
 
 private class MutableMediatorLiveData<T>(private val onNewValue: (T) -> Unit) : MediatorLiveData<T>() {
   override fun setValue(value: T) {
+    if (this.value == value) return
     super.setValue(value)
     onNewValue(value)
   }
 
   fun setValueSkipCallback(value: T) {
+    if (this.value == value) return
     super.setValue(value)
   }
 }

--- a/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlow.kt
+++ b/saved-state-handle/src/main/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlow.kt
@@ -6,7 +6,7 @@ import com.episode6.typed2.Key
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
 
-fun <T, BACKED_BY> SavedStateHandle.stateFlow(
+fun <T, BACKED_BY> SavedStateHandle.getStateFlow(
   key: Key<T, BACKED_BY, *, *>,
   scope: CoroutineScope,
   started: SharingStarted,
@@ -14,7 +14,7 @@ fun <T, BACKED_BY> SavedStateHandle.stateFlow(
   map { key.mapper.mapGet(it) }.stateIn(scope, started, initialValue = key.mapper.mapGet(value))
 }
 
-fun <T, BACKED_BY> SavedStateHandle.sharedFlow(
+fun <T, BACKED_BY> SavedStateHandle.getSharedFlow(
   key: AsyncKey<T, BACKED_BY, *, *>,
   scope: CoroutineScope,
   started: SharingStarted,

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -39,11 +39,9 @@ class GetLiveDataTest {
 
   @get:Rule val instantExecutor = InstantTaskExecutorRule()
 
-  val dispatcher = StandardTestDispatcher()
-
   @Before
   fun setup() {
-    Dispatchers.setMain(dispatcher)
+    Dispatchers.setMain(StandardTestDispatcher())
   }
 
   @After

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -164,7 +164,7 @@ class GetLiveDataTest {
       onGeneric { getLiveData<String?>(any(), anyOrNull()) } doReturn backingLiveData
     }
 
-    val result = savedStateHandle.getLiveData(this, Keys.asyncRequiredInt)
+    val result = savedStateHandle.getLiveData(Keys.asyncRequiredInt, this)
     assertThat(result.value).isNull()
     result.asFlow().testIn(this)
   }
@@ -176,7 +176,7 @@ class GetLiveDataTest {
     }
 
     launch {
-      val result: MutableLiveData<Int> = savedStateHandle.getLiveData(this, Keys.asyncRequiredInt)
+      val result: MutableLiveData<Int> = savedStateHandle.getLiveData(Keys.asyncRequiredInt, this)
 
       result.asFlow().test {
         assertThat(awaitItem()).isEqualTo(5)

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
@@ -41,7 +41,7 @@ class GetStateFlowTest {
     }
 
     launch {
-      val result: StateFlow<Int> = savedStateHandle.stateFlow(Keys.intKey, this, SharingStarted.Eagerly)
+      val result: StateFlow<Int> = savedStateHandle.getStateFlow(Keys.intKey, this, SharingStarted.Eagerly)
 
       assertThat(result.value).isEqualTo(2)
 
@@ -64,7 +64,7 @@ class GetStateFlowTest {
     }
 
     launch {
-      val result: StateFlow<Int?> = savedStateHandle.stateFlow(Keys.nullableIntKey, this, SharingStarted.Eagerly)
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(Keys.nullableIntKey, this, SharingStarted.Eagerly)
 
       assertThat(result.value).isNull()
 
@@ -86,7 +86,7 @@ class GetStateFlowTest {
       onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
     }
 
-    assertThat { savedStateHandle.stateFlow(Keys.requiredInt, this, SharingStarted.Eagerly) }
+    assertThat { savedStateHandle.getStateFlow(Keys.requiredInt, this, SharingStarted.Eagerly) }
       .isFailure().hasClass(RequiredKeyMissingException::class)
   }
 
@@ -97,7 +97,7 @@ class GetStateFlowTest {
     }
 
     launch {
-      val result: StateFlow<Int?> = savedStateHandle.stateFlow(Keys.requiredInt, this, SharingStarted.Eagerly)
+      val result: StateFlow<Int?> = savedStateHandle.getStateFlow(Keys.requiredInt, this, SharingStarted.Eagerly)
 
       assertThat(result.value).isEqualTo(5)
 
@@ -120,7 +120,7 @@ class GetStateFlowTest {
       onGeneric { getStateFlow<String?>(any(), anyOrNull()) } doReturn backingStateFlow
     }
 
-    val result = savedStateHandle.sharedFlow(Keys.asyncRequiredInt, this, SharingStarted.Eagerly)
+    val result = savedStateHandle.getSharedFlow(Keys.asyncRequiredInt, this, SharingStarted.Eagerly)
     assertThat(result.first()).isNull()
     result.testIn(this)
   }
@@ -132,7 +132,7 @@ class GetStateFlowTest {
     }
 
     launch {
-      val result: SharedFlow<Int?> = savedStateHandle.sharedFlow(Keys.asyncRequiredInt, this, SharingStarted.Eagerly)
+      val result: SharedFlow<Int?> = savedStateHandle.getSharedFlow(Keys.asyncRequiredInt, this, SharingStarted.Eagerly)
 
       result.test {
         assertThat(awaitItem()).isEqualTo(5)


### PR DESCRIPTION
 - rename stateFlow / sharedFlow methods to getStateFlow / getSharedFlow
 - the getLiveData impl was emitting more values than expected, force it to distinctUntilChanged except for the first emission. This actually matches the impl of `LiveData.distinctUntilChanged()`