### PR TITLE
Make async keys first class citizens

### DIFF
--- a/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncKey.kt
@@ -1,5 +1,10 @@
 package com.episode6.typed2
 
+class AsyncKeyBacker<BACKED_BY : Any?, in GETTER : KeyValueGetter, in SETTER : KeyValueSetter> internal constructor(
+  val getBackingData: suspend (GETTER) -> BACKED_BY,
+  val setBackingData: suspend (SETTER, BACKED_BY) -> Unit,
+)
+
 class AsyncKeyMapper<T : Any?, BACKED_BY : Any?> internal constructor(
   val mapGet: suspend (BACKED_BY) -> T,
   val mapSet: suspend (T) -> BACKED_BY,
@@ -9,7 +14,7 @@ class AsyncKey<T : Any?, BACKED_BY : Any?, in GETTER : KeyValueGetter, in SETTER
   override val name: String,
   internal val outputDefault: AsyncOutputDefault<T>?,
   override val backingTypeInfo: KeyBackingTypeInfo<BACKED_BY>,
-  val backer: KeyBacker<BACKED_BY, GETTER, SETTER>,
+  val backer: AsyncKeyBacker<BACKED_BY, GETTER, SETTER>,
   val mapper: AsyncKeyMapper<T, BACKED_BY>,
   internal val newKeyCallback: (KeyDescriptor<*, *>) -> Unit,
 ) : KeyDescriptor<T, BACKED_BY> {

--- a/core/src/main/kotlin/com/episode6/typed2/AsyncNamespaces.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/AsyncNamespaces.kt
@@ -1,0 +1,11 @@
+package com.episode6.typed2
+
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+interface AsyncMappingInlineBackingNamespace {
+  fun <T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, BACKED_BY, GETTER, SETTER>.async(
+    context: CoroutineContext = Dispatchers.Default,
+  ): AsyncKey<T, BACKED_BY, GETTER, SETTER> = async(mapperContext = context, backerContext = EmptyCoroutineContext)
+}

--- a/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/KeyTransforms.kt
@@ -1,6 +1,5 @@
 package com.episode6.typed2
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
@@ -72,8 +71,8 @@ fun <T : Any?, R : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : Key
 )
 
 fun <T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> Key<T, BACKED_BY, GETTER, SETTER>.async(
-  mapperContext: CoroutineContext? = Dispatchers.Default,
-  backerContext: CoroutineContext? = null,
+  mapperContext: CoroutineContext,
+  backerContext: CoroutineContext,
 ): AsyncKey<T, BACKED_BY, GETTER, SETTER> = AsyncKey(
   name = name,
   outputDefault = outputDefault?.async(),
@@ -83,22 +82,14 @@ fun <T : Any?, BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSette
   newKeyCallback = newKeyCallback,
 )
 
-private fun <T : Any?, BACKED_BY : Any?> KeyMapper<T, BACKED_BY>.async(context: CoroutineContext?) = AsyncKeyMapper<T, BACKED_BY>(
-  mapGet = { withNullableContext(context) { mapGet(it) } },
-  mapSet = { withNullableContext(context) { mapSet(it) } },
+private fun <T : Any?, BACKED_BY : Any?> KeyMapper<T, BACKED_BY>.async(context: CoroutineContext) = AsyncKeyMapper<T, BACKED_BY>(
+  mapGet = { withContext(context) { mapGet(it) } },
+  mapSet = { withContext(context) { mapSet(it) } },
 )
 
 private fun <BACKED_BY : Any?, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBacker<BACKED_BY, GETTER, SETTER>.async(
-  context: CoroutineContext?,
+  context: CoroutineContext,
 ) = AsyncKeyBacker<BACKED_BY, GETTER, SETTER>(
-  getBackingData = { withNullableContext(context) { getBackingData(it) } },
-  setBackingData = { setter, backedBy -> withNullableContext(context) { setBackingData(setter, backedBy) } }
+  getBackingData = { withContext(context) { getBackingData(it) } },
+  setBackingData = { setter, backedBy -> withContext(context) { setBackingData(setter, backedBy) } }
 )
-
-private suspend fun <T> withNullableContext(
-  context: CoroutineContext?,
-  block: suspend () -> T,
-): T = when (context) {
-  null -> block()
-  else -> withContext(context) { block() }
-}

--- a/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/NativeKeys.kt
@@ -55,6 +55,59 @@ object NativeKeys {
     get = get,
     set = set,
   )
+
+  fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> createAsync(
+    keyBuilder: KeyBuilder,
+    backingDefault: T,
+    backingClass: KClass<T>,
+    get: suspend GETTER.() -> T,
+    set: suspend SETTER.(T) -> Unit,
+  ): AsyncKey<T, T, GETTER, SETTER> = AsyncKey(
+    name = keyBuilder.name,
+    outputDefault = null,
+    backingTypeInfo = KeyBackingTypeInfo(kclass = backingClass, default = backingDefault),
+    backer = AsyncKeyBacker(getBackingData = get, setBackingData = set),
+    mapper = AsyncKeyMapper({ it }, { it }),
+    newKeyCallback = keyBuilder.newKeyCallback
+  )
+
+  fun <T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> createAsync(
+    keyBuilder: KeyBuilder,
+    backingClass: KClass<T>,
+    get: suspend GETTER.() -> T?,
+    set: suspend SETTER.(T?) -> Unit,
+  ): AsyncKey<T?, T?, GETTER, SETTER> = AsyncKey(
+    name = keyBuilder.name,
+    outputDefault = null,
+    backingTypeInfo = KeyBackingTypeInfo(kclass = backingClass, default = null),
+    backer = AsyncKeyBacker(getBackingData = get, setBackingData = set),
+    mapper = AsyncKeyMapper({ it }, { it }),
+    newKeyCallback = keyBuilder.newKeyCallback
+  )
+
+  inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> createAsync(
+    keyBuilder: KeyBuilder,
+    backingDefault: T,
+    noinline get: suspend GETTER.() -> T,
+    noinline set: suspend SETTER.(T) -> Unit,
+  ): AsyncKey<T, T, GETTER, SETTER> = createAsync(
+    keyBuilder,
+    backingDefault = backingDefault,
+    backingClass = T::class,
+    get = get,
+    set = set,
+  )
+
+  inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> createAsync(
+    keyBuilder: KeyBuilder,
+    noinline get: suspend GETTER.() -> T?,
+    noinline set: suspend SETTER.(T?) -> Unit,
+  ): AsyncKey<T?, T?, GETTER, SETTER> = createAsync(
+    keyBuilder,
+    backingClass = T::class,
+    get = get,
+    set = set,
+  )
 }
 
 internal inline fun <reified T : Any, GETTER : KeyValueGetter, SETTER : KeyValueSetter> KeyBuilder.nativeKey(

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BaseBundleKeys.kt
@@ -12,7 +12,7 @@ interface BaseBundleKeyBuilder : PrimitiveKeyBuilder
  * This namespace should only be needed if you want to explicitly declare a set of keys
  * that can be shared between Bundle & PersistableBundle.
  */
-open class BaseBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
+open class BaseBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace, AsyncMappingInlineBackingNamespace {
   private class Builder(override val name: String) : BaseBundleKeyBuilder
 
   protected fun key(name: String): BaseBundleKeyBuilder = Builder(prefix + name)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/BundleKeys.kt
@@ -13,7 +13,7 @@ typealias BundleKey<T, BACKED_BY> = Key<T, BACKED_BY, BundleValueGetter, BundleV
 typealias AsyncBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, BundleValueGetter, BundleValueSetter>
 
 interface BundleKeyBuilder : BaseBundleKeyBuilder
-open class BundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
+open class BundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace, AsyncMappingInlineBackingNamespace {
   private class Builder(override val name: String) : BundleKeyBuilder
 
   protected fun key(name: String): BundleKeyBuilder = Builder(prefix + name)

--- a/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/bundles/PersistableBundleKeys.kt
@@ -8,7 +8,7 @@ typealias PersistableBundleKey<T, BACKED_BY> = Key<T, BACKED_BY, PersistableBund
 typealias AsyncPersistableBundleKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PersistableBundleValueGetter, PersistableBundleValueSetter>
 
 interface PersistableBundleKeyBuilder : BaseBundleKeyBuilder
-open class PersistableBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace {
+open class PersistableBundleKeyNamespace(private val prefix: String = "") : RequiredEnabledKeyNamespace, AsyncMappingInlineBackingNamespace {
   private class Builder(override val name: String) : PersistableBundleKeyBuilder
 
   protected fun key(name: String): PersistableBundleKeyBuilder = Builder(prefix + name)

--- a/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
+++ b/core/src/main/kotlin/com/episode6/typed2/sharedprefs/PrefKeys.kt
@@ -6,7 +6,7 @@ typealias PrefKey<T, BACKED_BY> = Key<T, BACKED_BY, PrefValueGetter, PrefValueSe
 typealias AsyncPrefKey<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrefValueGetter, PrefValueSetter>
 
 interface PrefKeyBuilder : PrimitiveKeyBuilder
-open class PrefKeyNamespace(private val prefix: String = "") {
+open class PrefKeyNamespace(private val prefix: String = "") : AsyncMappingInlineBackingNamespace {
   private class Builder(override val name: String) : PrefKeyBuilder
 
   protected fun key(name: String): PrefKeyBuilder = Builder(prefix + name)

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,8 +99,8 @@ val navController: NavController = TODO()
 
 fun main() {
   // can pull nav arguments from either SavedStateHandles or Bundles
-  val someInt: Int = savedStateHandle.get(Arguments.MY_INT)
-  val someString: String? = savedStateHandle.get(Arguments.MY_STRING)
+  val someInt: Int = savedStateHandle.get(MyScreen.MY_INT)
+  val someString: String? = savedStateHandle.get(MyScreen.MY_STRING)
 
   // type-safe navigation arguments
   navController.navigateTo(MyScreen) {

--- a/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
+++ b/navigation-compose/src/main/kotlin/com/episode6/typed2/navigation/compose/NavScreen.kt
@@ -7,7 +7,7 @@ typealias NavArg<T, BACKED_BY> = Key<T, BACKED_BY, PrimitiveKeyValueGetter, Prim
 typealias AsyncNavArg<T, BACKED_BY> = AsyncKey<T, BACKED_BY, PrimitiveKeyValueGetter, PrimitiveKeyValueSetter>
 
 interface NavArgBuilder : PrimitiveKeyBuilder
-open class NavScreen(val name: String, private val argPrefix: String = "") : RequiredEnabledKeyNamespace {
+open class NavScreen(val name: String, private val argPrefix: String = "") : RequiredEnabledKeyNamespace, AsyncMappingInlineBackingNamespace {
 
   private val _args = LinkedHashMap<String, KeyDescriptor<*, *>>()
   internal val args: List<KeyDescriptor<*, *>> get() = _args.values.toList()

--- a/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/test_screens.kt
+++ b/navigation-compose/src/test/kotlin/com/episode6/typed2/navigation/compose/test_screens.kt
@@ -1,6 +1,5 @@
 package com.episode6.typed2.navigation.compose
 
-import com.episode6.typed2.async
 import com.episode6.typed2.int
 import com.episode6.typed2.string
 

--- a/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/IntentInstrumentedTest.kt
+++ b/sample-app/src/androidTest/kotlin/com/episode6/typed2/sampleapp/IntentInstrumentedTest.kt
@@ -7,7 +7,6 @@ import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.bundles.getExtra
 import com.episode6.typed2.bundles.setExtra

--- a/sample-app/src/main/kotlin/com/episode6/typed2/sampleapp/screen/navargs/NavArgScreenApi.kt
+++ b/sample-app/src/main/kotlin/com/episode6/typed2/sampleapp/screen/navargs/NavArgScreenApi.kt
@@ -1,6 +1,5 @@
 package com.episode6.typed2.sampleapp.screen.navargs
 
-import com.episode6.typed2.async
 import com.episode6.typed2.gson.gson
 import com.episode6.typed2.kotlinx.serialization.json.json
 import com.episode6.typed2.navigation.compose.NavScreen

--- a/sample-app/src/main/kotlin/com/episode6/typed2/sampleapp/screen/sharedpref/SharedPrefScreenUi.kt
+++ b/sample-app/src/main/kotlin/com/episode6/typed2/sampleapp/screen/sharedpref/SharedPrefScreenUi.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
-import com.episode6.typed2.async
 import com.episode6.typed2.gson.gson
 import com.episode6.typed2.kotlinx.serialization.json.json
 import com.episode6.typed2.sampleapp.data.KtxSerializable

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetLiveDataTest.kt
@@ -14,7 +14,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
 import com.episode6.typed2.RequiredKeyMissingException
-import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.int
 import kotlinx.coroutines.Dispatchers

--- a/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
+++ b/saved-state-handle/src/test/kotlin/com/episode6/typed2/savedstatehandle/GetStateFlowTest.kt
@@ -11,7 +11,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNull
 import com.episode6.typed2.RequiredKeyMissingException
-import com.episode6.typed2.async
 import com.episode6.typed2.bundles.BundleKeyNamespace
 import com.episode6.typed2.int
 import kotlinx.coroutines.ExperimentalCoroutinesApi


### PR DESCRIPTION
- Define AsyncKeyBacker with suspend methods
- Define public methods to create native AsyncKeys
- update .async() method to accept a 2nd CoroutineContext parameter and differentiate between mapperContext & backerContext