### PR TITLE
[VERSION] Release v2.0.0-alpha03

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ alias(libs.plugins.kotlin.serialization) apply false
 
 allprojects {
   group = "com.episode6.typed2"
-  version = "2.0.0-SNAPSHOT"
+  version = "2.0.0-alpha03"
 }
 description = "Type-safe keys for obnoxious key-value stores."
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-### v2.0.0-alpha03 - Unreleased
+### v2.0.0-alpha03 - Released 06/27/2026
 
 - Modernize build infrastructure: Kotlin 2.3.21, Gradle 9.5.1, Dokka 2.2.0, AGP 9.2.1, JVM target 17
 - Update GitHub Actions: checkout@v6, setup-java@v5, gradle/actions/setup-gradle@v6, JDK 23


### PR DESCRIPTION
Sets the release version for the `release/v2.0.0-alpha03` branch.

- `build.gradle.kts`: `2.0.0-SNAPSHOT` → `2.0.0-alpha03`
- `docs/CHANGELOG.md`: mark v2.0.0-alpha03 as Released 06/27/2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)