### PR TITLE
Bump actions/cache from v4 to v6

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
     - name: AVD cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: avd-cache
       with:
         path: |


### PR DESCRIPTION
## Summary
- Updates `actions/cache` in `build-and-check.yml` from `v4` to `v6`.
- `v4` runs on the now-deprecated Node 20 runtime (the source of the GitHub Actions warning); `v6` runs on Node 24.

## Notes
- `v6` requires Actions Runner `2.327.1+`, which is satisfied by `ubuntu-latest`.
- The cache usage here (AVD snapshot caching) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)