### PR TITLE
Bump actions/cache from v4 to v6

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
     - name: AVD cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: avd-cache
       with:
         path: |


### PR DESCRIPTION
## Summary
- Cherry-picks the `actions/cache` v4 → v6 bump (#83, merged to `main`) onto `release/v2.0.0-alpha03`.
- `v4` runs on the deprecated Node 20 runtime; `v6` runs on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)