### PR TITLE
Use self.versions.toml as source of truth for the version name

### DIFF
--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   RELEASE_CHECKLIST.md. Use whenever the user asks to "cut a release branch"
   (or to cut/create/start a new release branch): verifies main is green,
   creates release/v<VERSION>, and opens the snapshot-on-main and
-  release-on-branch version-bump PRs that update build.gradle.kts and
+  release-on-branch version-bump PRs that update self.versions.toml and
   docs/CHANGELOG.md.
 ---
 
@@ -30,14 +30,14 @@ Create two separate Pull Requests to update versions.
 - **Target Branch:** `main`
 - **PR Title:** `[VERSION] Snapshot v<NEXT_VERSION>-SNAPSHOT`
 - **Changes:**
-    - Update `version` in `build.gradle.kts`. **(VITAL)** When computing `<NEXT_VERSION>`, increment **only the patch version** (e.g., `2.2.0` → `2.2.1`). Never automatically increment the major or minor version — those bumps require explicit human decision.
+    - Update `version` in `self.versions.toml`. **(VITAL)** When computing `<NEXT_VERSION>`, increment **only the patch version** (e.g., `2.2.0` → `2.2.1`). Never automatically increment the major or minor version — those bumps require explicit human decision.
     - **(VITAL)** Update `docs/CHANGELOG.md` to include a new "Unreleased" section for the next version, AND update the version being released with its release date.
 
 #### PR 2: Release Version on Release Branch
 - **Target Branch:** `release/v<VERSION>`
 - **PR Title:** `[VERSION] Release v<VERSION>`
 - **Changes:**
-    - Update `version` in `build.gradle.kts` (remove `-SNAPSHOT` if present).
+    - Update `version` in `self.versions.toml` (remove `-SNAPSHOT` if present).
     - **(VITAL)** Update `docs/CHANGELOG.md` with the release date and the final version. Ensure all changes since the last release are documented.
 
 ### 4. Create Pull Requests

--- a/.agents/ship-release-skill/SKILL.md
+++ b/.agents/ship-release-skill/SKILL.md
@@ -2,14 +2,14 @@
 name: ship-release-skill
 description: >-
   Ship a release branch by publishing a GitHub release using the gh CLI. Parses
-  version from build.gradle.kts and gets release notes from docs/CHANGELOG.md.
+  version from self.versions.toml and gets release notes from docs/CHANGELOG.md.
 ---
 
 # Ship Release Branch Skill
 
 ## Overview
 This skill guides the agent in shipping a release branch by creating and publishing a GitHub release pointing to the tip of the release branch. It ensures consistency by:
-1. Resolving the release version directly from `build.gradle.kts` on the target release branch (never assuming the branch name matches the version name, as hotfixes are appended to existing release branches).
+1. Resolving the release version directly from `self.versions.toml` on the target release branch (never assuming the branch name matches the version name, as hotfixes are appended to existing release branches).
 2. Extracting release notes from the corresponding section in `docs/CHANGELOG.md`.
 3. Publishing the GitHub release using the `gh` CLI with matching tag name and release name (format: `v<VERSION>`).
 
@@ -19,7 +19,7 @@ This skill guides the agent in shipping a release branch by creating and publish
 ## Prerequisites
 - **Merge PRs via GitHub**: Ensure the version bump PR (and any hardening PRs) are merged via the GitHub UI or `gh pr merge`. **NEVER** use local merge commits on the release branch.
 - **Pull Latest**: Once PRs are merged on GitHub, checkout the release branch locally and pull the latest changes from `origin` to ensure the local branch is up-to-date before starting the release process.
-- **Verify Version**: The version in `build.gradle.kts` must NOT end with `-SNAPSHOT`. If it does, the release process must be aborted until the version is properly bumped.
+- **Verify Version**: The version in `self.versions.toml` must NOT end with `-SNAPSHOT`. If it does, the release process must be aborted until the version is properly bumped.
 
 ## Quick Start
 To perform a dry-run and verify release notes/version before shipping:
@@ -54,7 +54,7 @@ The skill uses the `./scripts/ship-release.py` script.
 ```
 
 ## Common Mistakes
-1. **Shipping a Snapshot**: Trying to ship when the version in `build.gradle.kts` still contains `-SNAPSHOT`. The script will detect this and fail.
+1. **Shipping a Snapshot**: Trying to ship when the version in `self.versions.toml` still contains `-SNAPSHOT`. The script will detect this and fail.
 2. **Missing Changelog Section**: Forgetting to update `docs/CHANGELOG.md` with the release version and date. The script will fail if the section matching `v<VERSION>` cannot be found.
 3. **Mismatched release notes**: Assuming the release notes can be typed manually. Always extract them directly from `docs/CHANGELOG.md` using the script to avoid discrepancies.
 4. **Stale Local Branch**: Forgetting to pull the latest changes from `origin` before shipping, which can lead to releasing an outdated version of the code.

--- a/.agents/ship-release-skill/skill.json
+++ b/.agents/ship-release-skill/skill.json
@@ -9,8 +9,8 @@
   "tags": ["release", "git", "github", "gh-cli"],
   "required_actions": [
     "Pull latest changes from origin to ensure local branch is up-to-date",
-    "Verify version in build.gradle.kts does not end with -SNAPSHOT (abort if it does)",
-    "Parse version from build.gradle.kts on the release branch",
+    "Verify version in self.versions.toml does not end with -SNAPSHOT (abort if it does)",
+    "Parse version from self.versions.toml on the release branch",
     "Extract release notes from docs/CHANGELOG.md",
     "Publish GitHub release using gh CLI pointing to the tip of the release branch"
   ]

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,34 @@
+## Typed2 Release Checklist
+
+(we should be able to automate most of this eventually)
+
+### Cut new Release Branch
+
+1. Ensure main branch is green
+2. `git checkout -b release/v<VERSION>`
+3. Push/track empty branch
+
+### Version bump PRs
+
+- Create 2 PRs to bump version
+    - `[VERSION] Snapshot v<version>` points at `main`
+    - `[VERSION] Release v<version>` points at new release branch
+    - Update version in files:
+        - `self.versions.toml`
+        - `docs/CHANGELOG.md`
+
+### Harden Release Branch
+
+- Fix any bugs on the `main` branch first then cherry-pick (via PR) into release branch
+
+### Release
+
+1. Create new release with new tag on github (pointing to release branch)
+2. Release/Close new repo on [sonatype](https://oss.sonatype.org/)
+
+### Hotfixes
+
+- We do not cut new release branches for hotfixes, instead we append to the effected release branch and add a new
+  release tag
+- All fixes (including hotfixes) should be applied to the `main` branch first whenever possible and cherry-picked onto
+  the appropriate release-branch for a hotfix.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,10 @@ alias(libs.plugins.kotlin.serialization) apply false
   id("config-site")
 }
 
+val selfVersion = self.versions.name.get()
 allprojects {
   group = "com.episode6.typed2"
-  version = "2.0.0-alpha04-SNAPSHOT"
+  version = selfVersion
 }
 description = "Type-safe keys for obnoxious key-value stores."
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### v2.0.0-alpha04 - Unreleased
 
+- Move version name source of truth into `self.versions.toml` (build.gradle.kts, `ship-release.py` and release skills now read it from there)
+
 
 ### v2.0.0-alpha03 - Released 06/27/2026
 

--- a/scripts/ship-release.py
+++ b/scripts/ship-release.py
@@ -22,18 +22,18 @@ def get_current_branch():
         sys.exit(1)
 
 def get_version():
-    gradle_file = "build.gradle.kts"
-    if not os.path.exists(gradle_file):
-        print(f"Error: {gradle_file} not found in the current directory.", file=sys.stderr)
+    version_file = "self.versions.toml"
+    if not os.path.exists(version_file):
+        print(f"Error: {version_file} not found in the current directory.", file=sys.stderr)
         sys.exit(1)
 
-    with open(gradle_file, "r") as f:
+    with open(version_file, "r") as f:
         content = f.read()
 
-    # Search for version = "..."
-    match = re.search(r'version\s*=\s*"([^"]+)"', content)
+    # Search for name = "..." (source of truth for the project version)
+    match = re.search(r'name\s*=\s*"([^"]+)"', content)
     if not match:
-        print("Error: Could not find version pattern in build.gradle.kts", file=sys.stderr)
+        print("Error: Could not find version pattern in self.versions.toml", file=sys.stderr)
         sys.exit(1)
 
     version = match.group(1)

--- a/self.versions.toml
+++ b/self.versions.toml
@@ -1,0 +1,2 @@
+[versions]
+name="2.0.0-alpha04-SNAPSHOT"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
   }
   versionCatalogs {
     create("libs") { from(files("libs.versions.toml")) }
+    create("self") { from(files("self.versions.toml")) }
   }
 }
 rootProject.name = "typed2"


### PR DESCRIPTION
Adopts the same pattern as [reflective-mockk](https://github.com/episode6/reflective-mockk): the project version lives in `self.versions.toml`, exposed to the build as the `self` version catalog.

- `self.versions.toml` added (`name="2.0.0-alpha04-SNAPSHOT"`), registered in `settings.gradle.kts`
- `build.gradle.kts` reads `self.versions.name` (captured in a script-level `val` since the catalog accessor isn't visible inside the `allprojects {}` closure)
- `scripts/ship-release.py` parses the version from `self.versions.toml`
- `release-branch-skill` and `ship-release-skill` updated to bump/verify the version there
- Adds `RELEASE_CHECKLIST.md` (matching the sibling repos) — the release-branch-skill already referenced it, but the file didn't exist in this repo until now

## Verification
- `./gradlew properties` resolves `version: 2.0.0-alpha04-SNAPSHOT`
- `scripts/ship-release.py --dry-run` parses the version and correctly aborts on `-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSTaK4rDzZbv2tyFiGg9M7