### PR TITLE
Add CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude Code only auto-loads `CLAUDE.md`, not `AGENTS.md`. This adds a relative symlink `CLAUDE.md -> AGENTS.md` so the existing repo instructions are automatically included in Claude Code's context on any clone.

No content changes — the symlink is the approach recommended in the Claude Code memory docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCNvzX3UiB5BinjvDe7MR8